### PR TITLE
Catalogue cosmetic improvements and logo links

### DIFF
--- a/catalogue.js
+++ b/catalogue.js
@@ -453,7 +453,7 @@ async function loadClubDetails(clubId) {
     try {
         const { data: clubData, error: clubError } = await supabaseClient
             .from('clubs')
-            .select('id, name, country')
+            .select('id, name, country, city, web, media')
             .eq('id', clubId)
             .single();
 
@@ -467,9 +467,8 @@ async function loadClubDetails(clubId) {
         } else {
             const countryInfo = countryCodeToDetails_Generic[clubData.country.toUpperCase()];
             const countryDisplayName = countryInfo ? countryInfo.name : clubData.country;
-            const countryFlag = countryCodeToFlagEmoji[clubData.country.toUpperCase()] || '';
-            
-            if(mainHeading) mainHeading.textContent = `${clubData.name} ${countryFlag} - Sticker Gallery`;
+
+            if(mainHeading) mainHeading.textContent = `${clubData.name} - Sticker Gallery`;
             
             const { count: totalClubsInCountry } = await supabaseClient
                 .from('clubs')
@@ -487,21 +486,34 @@ async function loadClubDetails(clubId) {
                 .eq('club_id', clubId)
                 .order('id', { ascending: true });
 
+            // Display club info blocks
+            let clubInfoHtml = '<div class="club-info-section">';
+            if (clubData.city) {
+                clubInfoHtml += `<p class="club-info-item">🌍 ${clubData.city}</p>`;
+            }
+            if (clubData.web) {
+                clubInfoHtml += `<p class="club-info-item">🌐 <a href="${clubData.web}" target="_blank" rel="noopener noreferrer">${clubData.web}</a></p>`;
+            }
+            if (clubData.media) {
+                clubInfoHtml += `<p class="club-info-item">#️⃣ ${clubData.media}</p>`;
+            }
+            clubInfoHtml += '</div>';
+
             if (stickersError) {
                 console.error(`Error fetching stickers for club ID ${clubId}:`, stickersError);
-                contentBodyHtml = `<p>Could not load stickers for this club: ${stickersError.message}</p>`;
+                contentBodyHtml = clubInfoHtml + `<p>Could not load stickers for this club: ${stickersError.message}</p>`;
             } else if (!stickersResponse || stickersResponse.length === 0) {
-                contentBodyHtml = '<p>No stickers found for this club.</p>';
+                contentBodyHtml = clubInfoHtml + '<p>No stickers found for this club.</p>';
             } else {
                 let galleryHtml = '<div class="sticker-gallery">';
-                stickersResponse.forEach(sticker => { 
+                stickersResponse.forEach(sticker => {
                     galleryHtml += `
                         <a href="catalogue.html?sticker_id=${sticker.id}" class="sticker-preview-link">
                             <img src="${sticker.image_url}" alt="Sticker ID ${sticker.id} for ${clubData.name}" class="sticker-preview-image">
                         </a>`;
                 });
                 galleryHtml += '</div>';
-                contentBodyHtml = galleryHtml;
+                contentBodyHtml = clubInfoHtml + galleryHtml;
             }
         }
         contentDiv.innerHTML = contentBodyHtml; 
@@ -596,8 +608,8 @@ async function loadStickerDetails(stickerId) {
                         <img src="${sticker.image_url}" alt="Sticker ${sticker.id} ${sticker.clubs ? `- ${sticker.clubs.name}`:''}" class="sticker-detail-image">
                     </div>
                     <div class="sticker-detail-info">
-                        <p><strong>🌍 Location Found:</strong> ${sticker.location || 'N/A'} <strong>📅 Date Found:</strong> ${sticker.found ? new Date(sticker.found).toLocaleDateString() : 'N/A'}</p>
-                        <p><strong>Fun fact:</strong> ${sticker.description || 'No description available.'}</p>
+                        <p><strong>🌍 Location Found:</strong> ${sticker.location || 'N/A'}</p>
+                        <p><strong>📅 Date Found:</strong> ${sticker.found ? new Date(sticker.found).toLocaleDateString() : 'N/A'}</p>
                     </div>
                 </div>
             `;

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 <body class="home-page">
     <header class="app-header">
         <div class="logo-container">
-           <img src="/logo.png" alt="StickerHunt Logo" id="app-logo">
+           <a href="/index.html"><img src="/logo.png" alt="StickerHunt Logo" id="app-logo"></a>
         </div>
     </header>
 

--- a/quiz.html
+++ b/quiz.html
@@ -23,7 +23,7 @@
 <body>
     <header class="app-header">
         <div class="logo-container">
-           <img src="/logo.png" alt="StickerHunt Logo" id="app-logo">
+           <a href="/index.html"><img src="/logo.png" alt="StickerHunt Logo" id="app-logo"></a>
         </div>
         <div id="auth-section">
              <button id="login-button" class="btn btn-primary google-login" style="display: none;">

--- a/style.css
+++ b/style.css
@@ -445,6 +445,89 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
     display: inline-block; /* Ð©Ð¾Ð± margin-top Ð¿Ñ€Ð°Ñ†ÑŽÐ²Ð°Ð² Ñ– ÐºÐ½Ð¾Ð¿ÐºÐ° Ð½Ðµ Ñ€Ð¾Ð·Ñ‚ÑÐ³ÑƒÐ²Ð°Ð»Ð°ÑÑŒ Ð½Ð° Ð²ÑÑŽ ÑˆÐ¸Ñ€Ð¸Ð½Ñƒ */
 }
 
+/* Club info section */
+.club-info-section {
+    text-align: left;
+    margin-bottom: calc(var(--spacing-unit) * 3);
+    padding: 0;
+}
+
+.club-info-item {
+    font-size: 1.1em;
+    margin-bottom: calc(var(--spacing-unit) * 1.5);
+    line-height: 1.5;
+    color: var(--color-text);
+}
+
+.club-info-item a {
+    color: var(--color-link);
+    text-decoration: none;
+    word-break: break-all;
+}
+
+@media (hover: hover) {
+    .club-info-item a:hover {
+        color: var(--color-link-hover);
+        text-decoration: underline;
+    }
+}
+
+/* Sticker detail page styles */
+.sticker-detail-view {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: left;
+}
+
+.sticker-detail-image-container {
+    width: 150px;
+    height: 150px;
+    margin: 0 auto calc(var(--spacing-unit) * 3) auto;
+    background-color: var(--color-secondary-bg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.sticker-detail-image {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+.sticker-detail-info {
+    width: 100%;
+    max-width: 600px;
+    text-align: left;
+}
+
+.sticker-detail-info p {
+    font-size: 1.2em;
+    margin-bottom: calc(var(--spacing-unit) * 2);
+    line-height: 1.6;
+    color: var(--color-text);
+}
+
+.sticker-detail-info strong {
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+@media (max-width: 600px) {
+    .sticker-detail-image-container {
+        width: 90%;
+        height: auto;
+        aspect-ratio: 1 / 1;
+    }
+
+    .sticker-detail-info p {
+        font-size: 1em;
+    }
+}
 /* ------------------------------ */
 /* Responsiveness                 */
 /* ------------------------------ */


### PR DESCRIPTION
- Add homepage link on logo across all pages (index, quiz, catalogue)
- Remove country flag from club page title
- Add club info section (city, web, social media) on club pages
- Reduce sticker detail image size by half (150px, 90% on mobile)
- Remove Fun fact block from sticker detail page
- Reformat Location and Date blocks to separate lines with left alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)