### PR TITLE
Fix UI issues and styling conflicts

### DIFF
--- a/style.css
+++ b/style.css
@@ -455,7 +455,8 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
     margin-bottom: var(--spacing-unit);
     font-size: 1.1em; /* Ð Ð¾Ð·Ð¼Ñ–Ñ€ Ñ‚ÐµÐºÑÑ‚Ñƒ ÑÐº Ñƒ ÑÐ¿Ð¸ÑÐºÑƒ ÐºÑ€Ð°Ñ—Ð½ */
 
-.club-list li a {
+.club-list li a,
+#catalogue-content .club-list li a {
     text-decoration: none;
     color: var(--color-info-text);
     font-weight: 500;
@@ -551,6 +552,7 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
     width: 100%;
     height: 100%;
     object-fit: contain;
+    pointer-events: none;
 }
 
 .sticker-detail-info {
@@ -713,9 +715,9 @@ body.home-page #app-logo {
 }
 
 #home-sticker-container {
-    width: 400px;
-    max-width: 80%;
-    height: 400px;
+    width: 80%;
+    max-width: 400px;
+    aspect-ratio: 1 / 1;
     margin-bottom: calc(var(--spacing-unit) * 2);
     background-color: var(--color-secondary-bg);
     border: 1px solid var(--color-border);
@@ -724,7 +726,6 @@ body.home-page #app-logo {
     display: flex;
     align-items: center;
     justify-content: center;
-    aspect-ratio: 1 / 1;
 }
 
 #home-sticker-image {
@@ -758,6 +759,7 @@ body.home-page #app-logo {
     align-items: center;
     justify-content: center;
     box-sizing: border-box;
+    margin: 0;
 }
 
 #home-loading-indicator {


### PR DESCRIPTION
- Fix home page sticker size: use width: 80% with max-width: 400px instead of fixed width
- Fix button widths on home page by removing default margins
- Fix club links on country pages: add more specific CSS selector to override default link styles
- Fix sticker detail page cursor and tooltip: add pointer-events: none to image to ensure container handles events

All issues resolved:
1. Home sticker now respects 400px max width and 80% screen width
2. Play Quiz and View Catalogue buttons now have identical widths
3. Club links display in gray without underline (matching footer style)
4. Sticker detail page now shows cursor pointer and "View in full size" tooltip on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)