### PR TITLE
Update meta descriptions, logo, titles, navigation and keywords

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,14 +7,14 @@
     <link rel="icon" href="favicon.ico" type="image/x-icon">
 
     <!-- SEO Meta Tags -->
-    <meta name="description" content="Test your football sticker knowledge! Identify players from top clubs worldwide in this interactive quiz game. Play now and compete on the global leaderboard.">
+    <meta name="description" content="Browse our comprehensive database of football stickers from clubs around the world. Play quiz game now and compete on the global leaderboard.">
     <meta name="keywords" content="football, stickers, panini, quiz, database, soccer, player identification, leaderboard">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://stickerhunt.club/">
     <meta property="og:title" content="StickerHunt - Global Football Sticker Database">
-    <meta property="og:description" content="Test your football sticker knowledge! Identify players from top clubs worldwide in this interactive quiz game. Play now and compete on the global leaderboard.">
+    <meta property="og:description" content="Browse our comprehensive database of football stickers from clubs around the world. Play quiz game now and compete on the global leaderboard.">
     <meta property="og:image" content="https://stickerhunt.club/preview2.png">
     <meta property="og:site_name" content="StickerHunt">
 
@@ -22,7 +22,7 @@
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://stickerhunt.club/">
     <meta property="twitter:title" content="StickerHunt - Global Football Sticker Database">
-    <meta property="twitter:description" content="Test your football sticker knowledge! Identify players from top clubs worldwide in this interactive quiz game. Play now and compete on the global leaderboard.">
+    <meta property="twitter:description" content="Browse our comprehensive database of football stickers from clubs around the world. Play quiz game now and compete on the global leaderboard.">
     <meta property="twitter:image" content="https://stickerhunt.club/preview2.png">
     <meta property="twitter:site" content="@StickerHunting">
     <meta property="twitter:creator" content="@StickerHunting">

--- a/quiz.html
+++ b/quiz.html
@@ -7,14 +7,14 @@
     <link rel="icon" href="favicon.ico" type="image/x-icon">
 
     <!-- SEO Meta Tags -->
-    <meta name="description" content="Challenge yourself with football sticker identification! Guess the correct club from player stickers across multiple difficulty levels. Track your score and climb the leaderboard.">
+    <meta name="description" content="Challenge yourself with football sticker identification! Guess the correct club from stickers across multiple difficulty levels. Track your score and climb the leaderboard.">
     <meta name="keywords" content="football quiz, sticker game, football trivia, panini stickers, player identification, soccer quiz, guess the club">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://stickerhunt.club/quiz.html">
     <meta property="og:title" content="StickerHunt: Guess the Club - Football Sticker Quiz">
-    <meta property="og:description" content="Challenge yourself with football sticker identification! Guess the correct club from player stickers across multiple difficulty levels. Track your score and climb the leaderboard.">
+    <meta property="og:description" content="Challenge yourself with football sticker identification! Guess the correct club from stickers across multiple difficulty levels. Track your score and climb the leaderboard.">
     <meta property="og:image" content="https://stickerhunt.club/preview2.png">
     <meta property="og:site_name" content="StickerHunt">
 
@@ -22,7 +22,7 @@
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://stickerhunt.club/quiz.html">
     <meta property="twitter:title" content="StickerHunt: Guess the Club - Football Sticker Quiz">
-    <meta property="twitter:description" content="Challenge yourself with football sticker identification! Guess the correct club from player stickers across multiple difficulty levels. Track your score and climb the leaderboard.">
+    <meta property="twitter:description" content="Challenge yourself with football sticker identification! Guess the correct club from stickers across multiple difficulty levels. Track your score and climb the leaderboard.">
     <meta property="twitter:image" content="https://stickerhunt.club/preview2.png">
     <meta property="twitter:site" content="@StickerHunting">
     <meta property="twitter:creator" content="@StickerHunting">

--- a/style.css
+++ b/style.css
@@ -489,14 +489,14 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
 }
 
 .club-info-item a {
-    color: var(--color-link);
+    color: var(--color-info-text);
     text-decoration: none;
     word-break: break-all;
 }
 
 @media (hover: hover) {
     .club-info-item a:hover {
-        color: var(--color-link-hover);
+        color: var(--color-link);
         text-decoration: underline;
     }
 }
@@ -671,10 +671,9 @@ body.home-page .logo-container {
 }
 
 body.home-page #app-logo {
-    height: auto;
-    width: 40%;
-    max-width: 220px;
-    max-height: none;
+    height: calc(var(--header-height) * 0.5);
+    width: auto;
+    max-height: 32px;
 }
 
 .home-container {


### PR DESCRIPTION
Major improvements to catalogue pages and overall site metadata:

1. Meta Descriptions Updated:
   - index.html: Focus on database and quiz game
   - quiz.html: Removed "player" from description for brevity
   - catalogue.html: Unchanged (already optimal)

2. Home Page Logo Alignment:
   - Changed logo size to match catalogue page (32px height)
   - Logo properly centered in header

3. Club URL Links Styling:
   - Club info URLs now gray (var(--color-info-text))
   - Blue with underline on hover (matches footer style)

4. Dynamic Page Titles:
   - Country page: "🇧🇪 Belgium Clubs - Sticker Catalogue"
   - Club page: "Club Name Sticker Gallery - Sticker Catalogue"
   - Sticker page: "Sticker #83 Club Name - Sticker Catalogue"

5. Sticker Navigation:
   - Added prev/next sticker links on sticker detail pages
   - Shows "#ID" links positioned left and right of image
   - Only displays if prev/next stickers exist for the club
   - Styled with gray color matching site theme

6. Dynamic Meta Keywords:
   - Club and sticker pages now update meta keywords
   - Extracts hashtags from clubs.media field
   - Removes emojis and # symbols
   - Appends to existing keywords for better SEO

🤖 Generated with [Claude Code](https://claude.com/claude-code)