### PR TITLE
Fix critical CSS syntax error and responsive sizing

### DIFF
--- a/catalogue.html
+++ b/catalogue.html
@@ -15,7 +15,7 @@
     <meta property="og:url" content="https://stickerhunt.club/catalogue.html">
     <meta property="og:title" content="Sticker Catalogue - StickerHunt">
     <meta property="og:description" content="Browse our comprehensive database of football stickers from clubs around the world. Explore by country, view detailed sticker information, and discover the complete collection.">
-    <meta property="og:image" content="https://stickerhunt.club/preview2.png">
+    <meta property="og:image" content="https://stickerhunt.club/metash.png">
     <meta property="og:site_name" content="StickerHunt">
 
     <!-- Twitter -->
@@ -23,7 +23,7 @@
     <meta property="twitter:url" content="https://stickerhunt.club/catalogue.html">
     <meta property="twitter:title" content="Sticker Catalogue - StickerHunt">
     <meta property="twitter:description" content="Browse our comprehensive database of football stickers from clubs around the world. Explore by country, view detailed sticker information, and discover the complete collection.">
-    <meta property="twitter:image" content="https://stickerhunt.club/preview2.png">
+    <meta property="twitter:image" content="https://stickerhunt.club/metash.png">
     <meta property="twitter:site" content="@StickerHunting">
     <meta property="twitter:creator" content="@StickerHunting">
 

--- a/catalogue.js
+++ b/catalogue.js
@@ -450,11 +450,10 @@ async function loadCountryDetails(countryCode) {
             const countryDisplayName = countryInfo ? countryInfo.name : countryCode;
             contentBodyHtml = `<p>No clubs found for ${countryDisplayName} in the catalogue.</p>`;
         } else {
-            // Update page title with country flag and name
+            // Update page title with country name
             const countryInfo = countryCodeToDetails_Generic[countryCode];
             const countryDisplayName = countryInfo ? countryInfo.name : countryCode;
-            const countryFlag = countryInfo ? countryInfo.flag : '';
-            document.title = `${countryFlag} ${countryDisplayName} Clubs - Sticker Catalogue`;
+            document.title = `${countryDisplayName} Clubs - Sticker Catalogue`;
 
             // Get all club IDs to fetch sticker counts in one query
             const clubIds = clubsInCountry.map(club => club.id);
@@ -626,6 +625,10 @@ async function loadStickerDetails(stickerId) {
 
         let contentBodyHtml = '';
 
+        // Initialize navigation variables outside of conditional blocks
+        let prevStickerId = null;
+        let nextStickerId = null;
+
         if (stickerError || !sticker) {
             console.error(`Error fetching sticker details for ID ${stickerId}:`, stickerError);
             if(mainHeading) mainHeading.textContent = "Sticker Not Found";
@@ -675,9 +678,6 @@ async function loadStickerDetails(stickerId) {
                     .eq('club_id', sticker.club_id)
                     .order('id', { ascending: true });
 
-                let prevStickerId = null;
-                let nextStickerId = null;
-
                 if (clubStickers && clubStickers.length > 1) {
                     const currentIndex = clubStickers.findIndex(s => s.id === sticker.id);
                     if (currentIndex > 0) {
@@ -692,24 +692,33 @@ async function loadStickerDetails(stickerId) {
                  updateBreadcrumbs([{ text: `All Countries (${totalCountriesInCatalogue})`, link: 'catalogue.html' }]);
             }
 
-            // Navigation links for prev/next stickers
-            let prevLink = '';
-            let nextLink = '';
-            if (typeof prevStickerId !== 'undefined' && prevStickerId !== null) {
-                prevLink = `<a href="catalogue.html?sticker_id=${prevStickerId}" style="position: absolute; left: 10px; top: 50%; transform: translateY(-50%); color: var(--color-info-text); text-decoration: none; font-size: 1.2em;">#${prevStickerId}</a>`;
-            }
-            if (typeof nextStickerId !== 'undefined' && nextStickerId !== null) {
-                nextLink = `<a href="catalogue.html?sticker_id=${nextStickerId}" style="position: absolute; right: 10px; top: 50%; transform: translateY(-50%); color: var(--color-info-text); text-decoration: none; font-size: 1.2em;">#${nextStickerId}</a>`;
+            // Navigation links for prev/next stickers (positioned below image)
+            let navigationHtml = '';
+            if (prevStickerId !== null || nextStickerId !== null) {
+                navigationHtml = '<div style="display: flex; justify-content: space-between; align-items: center; margin-top: 16px; margin-bottom: 24px; gap: 16px;">';
+
+                if (prevStickerId !== null) {
+                    navigationHtml += `<a href="catalogue.html?sticker_id=${prevStickerId}" style="color: var(--color-info-text); text-decoration: none; font-size: 1.1em; font-weight: 500;">← #${prevStickerId}</a>`;
+                } else {
+                    navigationHtml += '<span style="visibility: hidden;">← #0</span>'; // Placeholder for alignment
+                }
+
+                if (nextStickerId !== null) {
+                    navigationHtml += `<a href="catalogue.html?sticker_id=${nextStickerId}" style="color: var(--color-info-text); text-decoration: none; font-size: 1.1em; font-weight: 500;">#${nextStickerId} →</a>`;
+                } else {
+                    navigationHtml += '<span style="visibility: hidden;">#0 →</span>'; // Placeholder for alignment
+                }
+
+                navigationHtml += '</div>';
             }
 
             // User's preferred structure for sticker details:
             contentBodyHtml = `
-                <div class="sticker-detail-view" style="position: relative;">
-                    ${prevLink}
+                <div class="sticker-detail-view">
                     <div class="sticker-detail-image-container" onclick="window.open('${sticker.image_url}', '_blank')">
                         <img src="${sticker.image_url}" alt="Sticker ${sticker.id} ${sticker.clubs ? `- ${sticker.clubs.name}`:''}" class="sticker-detail-image">
                     </div>
-                    ${nextLink}
+                    ${navigationHtml}
                     <div class="sticker-detail-info">
                         <p><strong>🌍 Location Found:</strong> ${sticker.location || 'N/A'}</p>
                         <p><strong>📅 Date Found:</strong> ${sticker.found ? new Date(sticker.found).toLocaleDateString() : 'N/A'}</p>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <meta property="og:url" content="https://stickerhunt.club/">
     <meta property="og:title" content="StickerHunt - Global Football Sticker Database">
     <meta property="og:description" content="Browse our comprehensive database of football stickers from clubs around the world. Play quiz game now and compete on the global leaderboard.">
-    <meta property="og:image" content="https://stickerhunt.club/preview2.png">
+    <meta property="og:image" content="https://stickerhunt.club/metash.png">
     <meta property="og:site_name" content="StickerHunt">
 
     <!-- Twitter -->
@@ -23,7 +23,7 @@
     <meta property="twitter:url" content="https://stickerhunt.club/">
     <meta property="twitter:title" content="StickerHunt - Global Football Sticker Database">
     <meta property="twitter:description" content="Browse our comprehensive database of football stickers from clubs around the world. Play quiz game now and compete on the global leaderboard.">
-    <meta property="twitter:image" content="https://stickerhunt.club/preview2.png">
+    <meta property="twitter:image" content="https://stickerhunt.club/metash.png">
     <meta property="twitter:site" content="@StickerHunting">
     <meta property="twitter:creator" content="@StickerHunting">
 

--- a/quiz.html
+++ b/quiz.html
@@ -15,7 +15,7 @@
     <meta property="og:url" content="https://stickerhunt.club/quiz.html">
     <meta property="og:title" content="StickerHunt: Guess the Club - Football Sticker Quiz">
     <meta property="og:description" content="Challenge yourself with football sticker identification! Guess the correct club from stickers across multiple difficulty levels. Track your score and climb the leaderboard.">
-    <meta property="og:image" content="https://stickerhunt.club/preview2.png">
+    <meta property="og:image" content="https://stickerhunt.club/metash.png">
     <meta property="og:site_name" content="StickerHunt">
 
     <!-- Twitter -->
@@ -23,7 +23,7 @@
     <meta property="twitter:url" content="https://stickerhunt.club/quiz.html">
     <meta property="twitter:title" content="StickerHunt: Guess the Club - Football Sticker Quiz">
     <meta property="twitter:description" content="Challenge yourself with football sticker identification! Guess the correct club from stickers across multiple difficulty levels. Track your score and climb the leaderboard.">
-    <meta property="twitter:image" content="https://stickerhunt.club/preview2.png">
+    <meta property="twitter:image" content="https://stickerhunt.club/metash.png">
     <meta property="twitter:site" content="@StickerHunting">
     <meta property="twitter:creator" content="@StickerHunting">
 


### PR DESCRIPTION
Fixed several important issues with catalogue pages and metadata:

1. Country Page Title:
   - Removed emoji flag from document title
   - Changed from "🇧🇪 Belgium Clubs" to "Belgium Clubs"
   - Cleaner appearance in browser tabs and bookmarks

2. Sticker Navigation Links:
   - Fixed scope issue with prevStickerId/nextStickerId variables
   - Moved variables declaration outside conditional blocks
   - Repositioned navigation links below image (not on sides)
   - Added arrows for better UX: "← #123" and "#125 →"
   - Proper alignment with invisible placeholders when only one link exists
   - Links now use consistent styling (gray text, 1.1em font)

3. Meta Tags Image Update:
   - Changed og:image from preview2.png to metash.png
   - Changed twitter:image from preview2.png to metash.png
   - Applied to all three pages: index.html, quiz.html, catalogue.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)