### PR TITLE
Fix OAuth redirect to always go to quiz.html

### DIFF
--- a/script.js
+++ b/script.js
@@ -210,18 +210,22 @@ async function loginWithGoogle() {
     showLoading();
 
     try {
+        // Build the redirect URL to quiz.html
+        const baseUrl = window.location.origin;
+        const redirectUrl = `${baseUrl}/quiz.html`;
+
+        console.log(`OAuth redirect URL: ${redirectUrl}`);
+
         const { error } = await supabaseClient.auth.signInWithOAuth({
             provider: 'google',
             options: {
-                redirectTo: window.location.href
+                redirectTo: redirectUrl
             }
         });
 
         if (error) throw error;
 
-        // Note: hideLoading() is not called here because the OAuth redirect
-        // will navigate away from the page. The loading will be hidden when
-        // the user returns via the auth state change listener.
+        console.log("OAuth redirect initiated...");
     } catch (error) {
         console.error("Login error:", error);
         showError(`Login failed: ${error.message}`);


### PR DESCRIPTION
ISSUE:
After Google OAuth, users were redirected to unpredictable URLs because redirectTo was set to window.location.href (the current page URL).

- If user clicked login from index.html → redirected back to index.html
- If user clicked login from catalogue.html → redirected to catalogue.html
- This caused confusion and empty page issues

SOLUTION:
Changed OAuth redirectTo to always point to quiz.html, which is the main application page for authenticated users.

CHANGES:

Before:
```javascript
redirectTo: window.location.href  // Could be any page
```

After:
```javascript
const baseUrl = window.location.origin;
const redirectUrl = `${baseUrl}/quiz.html`;
redirectTo: redirectUrl  // Always quiz.html
```

BENEFITS:
✅ Predictable redirect behavior
✅ Users always land on quiz.html after OAuth
✅ No more redirects to index or catalogue pages
✅ Clearer user flow
✅ Added logging for debugging

TESTING:
1. Click login from any page (index, quiz, catalogue)
2. Complete Google OAuth
3. Should always redirect to quiz.html
4. UI should load correctly on quiz.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)