### PR TITLE
Fix: Critical auth and profile display issues

### DIFF
--- a/catalogue.js
+++ b/catalogue.js
@@ -857,8 +857,8 @@ function updateAuthUI(user) {
         loginButton.style.display = 'none';
         userStatusElement.style.display = 'flex';
     } else {
-        // User is logged out
-        loginButton.style.display = 'inline-block';
+        // User is logged out - hide both menu elements
+        loginButton.style.display = 'none';
         userStatusElement.style.display = 'none';
     }
 }

--- a/index-script.js
+++ b/index-script.js
@@ -268,8 +268,8 @@ function updateAuthUI(user) {
         loginButton.style.display = 'none';
         userStatusElement.style.display = 'flex';
     } else {
-        // User is logged out
-        loginButton.style.display = 'inline-block';
+        // User is logged out - hide both menu elements
+        loginButton.style.display = 'none';
         userStatusElement.style.display = 'none';
     }
 }

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -365,8 +365,8 @@ function updateAuthUI(user) {
         // Update leaderboard to highlight user's score
         updateLeaderboard();
     } else {
-        // User is logged out
-        loginButton.style.display = 'inline-block';
+        // User is logged out - hide both menu elements
+        loginButton.style.display = 'none';
         userStatusElement.style.display = 'none';
     }
 }


### PR DESCRIPTION
Fixed 3 major issues:

1. Loading... instead of nickname on quiz page
   - Problem: checkAndCreateUserProfile cleared currentUserProfile on error
   - Solution: Preserve cached profile even if fetch fails
   - Only update currentUserProfile if new profile fetched successfully
   - Added detailed logging for debugging

2. Nickname editing not working
   - Problem: showNicknameEditForm silently failed if profile not loaded
   - Solution: Added extensive logging and user feedback
   - Show "Please wait for your profile to load..." if profile not ready
   - Better error messages for debugging

3. Sign in button showing for logged out users
   - Problem: loginButton shown in header menu for logged out users
   - Solution: Hide both loginButton and userStatus when logged out
   - Applied fix across all pages: index, catalogue, leaderboard, quiz
   - Clean empty header space for logged out users

Technical details:
- script.js: Enhanced profile caching logic, preserve cached data
- script.js: Improved showNicknameEditForm with logging
- index-script.js: Hide login button when logged out
- catalogue.js: Hide login button when logged out
- leaderboard.js: Hide login button when logged out

Benefits:
- Stable nickname display with cached data
- Better error handling and user feedback
- Clean UI for both logged in and logged out states
- Improved debugging capabilities