### PR TITLE
Feat: Add nickname editing to all pages and improve home page stability

### DIFF
--- a/catalogue.html
+++ b/catalogue.html
@@ -53,6 +53,11 @@
              <div id="user-status" style="display: none;">
                  <strong id="user-nickname" title="Click to edit nickname">Loading...</strong>
                  <button id="logout-button" class="btn-link">Logout</button>
+                 <form id="edit-nickname-form" style="display: none;">
+                     <input type="text" id="nickname-input" placeholder="Enter new nickname" required minlength="3" maxlength="25" size="15">
+                     <button type="submit" class="btn btn-primary">Save</button>
+                     <button type="button" id="cancel-edit-nickname-button" class="btn btn-secondary">Cancel</button>
+                 </form>
              </div>
          </div>
     </header>

--- a/index.html
+++ b/index.html
@@ -51,8 +51,13 @@
                  <span>Sign in with Google</span>
              </button>
              <div id="user-status" style="display: none;">
-                 <strong id="user-nickname" title="Your username">Loading...</strong>
+                 <strong id="user-nickname" title="Click to edit nickname">Loading...</strong>
                  <button id="logout-button" class="btn-link">Logout</button>
+                 <form id="edit-nickname-form" style="display: none;">
+                     <input type="text" id="nickname-input" placeholder="Enter new nickname" required minlength="3" maxlength="25" size="15">
+                     <button type="submit" class="btn btn-primary">Save</button>
+                     <button type="button" id="cancel-edit-nickname-button" class="btn btn-secondary">Cancel</button>
+                 </form>
              </div>
          </div>
     </header>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -51,8 +51,13 @@
                  <span>Sign in with Google</span>
              </button>
              <div id="user-status" style="display: none;">
-                 <strong id="user-nickname" title="Your username">Loading...</strong>
+                 <strong id="user-nickname" title="Click to edit nickname">Loading...</strong>
                  <button id="logout-button" class="btn-link">Logout</button>
+                 <form id="edit-nickname-form" style="display: none;">
+                     <input type="text" id="nickname-input" placeholder="Enter new nickname" required minlength="3" maxlength="25" size="15">
+                     <button type="submit" class="btn btn-primary">Save</button>
+                     <button type="button" id="cancel-edit-nickname-button" class="btn btn-secondary">Cancel</button>
+                 </form>
              </div>
          </div>
     </header>


### PR DESCRIPTION
Added features:
1. Nickname editing on all pages (index, catalogue, leaderboard)
   - Added edit nickname form to all HTML pages
   - Added click listeners on nickname elements
   - Implemented showNicknameEditForm, hideNicknameEditForm, handleNicknameSave
   - Users can now edit their nickname from any page, not just quiz
   - Form appears on click with current nickname pre-filled

2. Improved home page stability
   - Added try-catch around setupNicknameEditing to prevent blocking
   - Added detailed logging for data loading process
   - Ensures random sticker and total count load properly
   - Better error handling for initialization

Technical implementation:
- index.html: Added edit form with 3-25 char validation
- index-script.js: Added nickname editing functions, improved error handling
- catalogue.html: Added edit form
- catalogue.js: Added nickname editing with DOM element initialization
- leaderboard.html: Added edit form
- leaderboard.js: Added nickname editing with leaderboard auto-update

Benefits:
- Consistent user experience across all pages
- Users can edit nickname from anywhere
- Better error handling prevents page initialization failures
- Proper form validation and user feedback