### PR TITLE
Fix: remove double URL encoding for sticker images

### DIFF
--- a/catalogue.js
+++ b/catalogue.js
@@ -724,13 +724,10 @@ async function loadStickerDetails(stickerId) {
                 navigationHtml += '</div>';
             }
 
-            // Sanitize image URL to prevent XSS
-            const sanitizedImageUrl = encodeURI(sticker.image_url);
-
             contentBodyHtml = `
                 <div class="sticker-detail-view">
-                    <div class="sticker-detail-image-container" onclick="window.open('${sanitizedImageUrl}', '_blank')">
-                        <img src="${sanitizedImageUrl}"
+                    <div class="sticker-detail-image-container" onclick="window.open('${sticker.image_url}', '_blank')">
+                        <img src="${sticker.image_url}"
                              alt="Sticker ${sticker.id} ${sticker.clubs ? `- ${sticker.clubs.name}` : ''}"
                              class="sticker-detail-image"
                              decoding="async">


### PR DESCRIPTION
The sticker detail page was applying encodeURI() to image URLs that were already URL-encoded in the database. This caused paths with spaces like "COL Independiente Santa Fe" to become double-encoded (%20 → %2520), breaking image loading for clubs with spaces in their names.