### PR TITLE
Fix: add Northern Ireland (NIR) to country mappings

### DIFF
--- a/catalogue.js
+++ b/catalogue.js
@@ -207,6 +207,7 @@ const countryCodeToDetails_Generic = {
     "ENG": { name: "England", continent: "Europe" },
     "SCO": { name: "Scotland", continent: "Europe" },
     "WLS": { name: "Wales", continent: "Europe" },
+    "NIR": { name: "Northern Ireland", continent: "Europe" },
 };
 
 const countryCodeToFlagEmoji = {
@@ -232,7 +233,7 @@ const countryCodeToFlagEmoji = {
     "CHE": "🇨🇭", "SYR": "🇸🇾", "TWN": "🇹🇼", "TZA": "🇹🇿", "THA": "🇹🇭", "TGO": "🇹🇬", "TUN": "🇹🇳",
     "TUR": "🇹🇷", "UGA": "🇺🇬", "UKR": "🇺🇦", "ARE": "🇦🇪", "GBR": "🇬🇧", "USA": "🇺🇸", "URY": "🇺🇾",
     "UZB": "🇺🇿", "VEN": "🇻🇪", "VNM": "🇻🇳", "YEM": "🇾🇪", "ZMB": "🇿🇲", "ZWE": "🇿🇼",
-    "ENG": "🏴󠁧󠁢󠁥󠁮󠁧󠁿", "SCO": "🏴󠁧󠁢󠁳󠁣󠁴󠁿", "WLS": "🏴󠁧󠁢󠁷󠁬󠁳󠁿"
+    "ENG": "🏴󠁧󠁢󠁥󠁮󠁧󠁿", "SCO": "🏴󠁧󠁢󠁳󠁣󠁴󠁿", "WLS": "🏴󠁧󠁢󠁷󠁬󠁳󠁿", "NIR": "🇬🇧"
 };
 
 let totalCountriesInCatalogue = 0;


### PR DESCRIPTION
- Added NIR to countryCodeToDetails_Generic with Europe continent
- Added NIR flag emoji (using UK flag since no official NI emoji exists)

This fixes the issue where Northern Ireland clubs were displayed under "Other Countries / Unclassified" without a flag instead of Europe.