### PR TITLE
Fix: disable image transformations (requires Pro Plan)

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -147,6 +147,15 @@ function getOptimizedImageUrl(imageUrl, options = {}) {
         return imageUrl;
     }
 
+    // IMPORTANT: Image Transformations require Supabase Pro Plan or above
+    // Set this to true when Pro Plan is active to enable optimizations
+    const ENABLE_IMAGE_TRANSFORMATIONS = false;
+
+    if (!ENABLE_IMAGE_TRANSFORMATIONS) {
+        // Return original URL when transformations are not available
+        return imageUrl;
+    }
+
     const {
         width,
         height,


### PR DESCRIPTION
Added ENABLE_IMAGE_TRANSFORMATIONS flag set to false by default. Supabase Image Transformations require Pro Plan - on Free Plan the /render/image/ endpoint returns errors and images don't load.

When Pro Plan is activated, set ENABLE_IMAGE_TRANSFORMATIONS = true to enable WebP conversion and resizing optimizations.