### PR TITLE
Optimize home page sticker loading speed

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://rbmeslzlbsolkxnvesqb.supabase.co">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="style.css">
@@ -70,9 +71,8 @@
 
         <div id="featured-sticker">
             <div id="home-sticker-container">
-                <img id="home-sticker-image" src="" alt="Featured Sticker">
+                <img id="home-sticker-image" src="" alt="Featured Sticker" fetchpriority="high">
             </div>
-            <h2 id="home-club-name">Loading...</h2>
         </div>
 
         <div class="home-actions">

--- a/style.css
+++ b/style.css
@@ -743,15 +743,6 @@ body.home-page #app-logo {
     object-fit: contain;
 }
 
-#home-club-name {
-    font-size: 0.9em;
-    font-weight: 600;
-    color: var(--color-text);
-    text-align: center;
-    margin: 0;
-    line-height: 1.3;
-}
-
 .home-actions {
     display: flex;
     flex-direction: column;
@@ -813,10 +804,6 @@ body.home-page #app-logo {
         margin-bottom: var(--spacing-unit);
     }
 
-    #home-club-name {
-        font-size: 0.85em;
-    }
-
     #featured-sticker {
         margin-bottom: calc(var(--spacing-unit) * 1.5);
     }
@@ -835,11 +822,6 @@ body.home-page #app-logo {
 
     .home-subtitle {
         font-size: 0.95em;
-    }
-
-
-    #home-club-name {
-        font-size: 1.3em;
     }
 }
 


### PR DESCRIPTION
- Remove club name caption from under the sticker image
- Load sticker, auth, and sticker count in parallel (not sequentially)
- Add preconnect hint for Supabase storage domain
- Add fetchpriority="high" to sticker image
- Simplify sticker query (no longer need club name join)
- Remove unused #home-club-name CSS styles