### PR TITLE
Add OpenStreetMap location preview for stickers with coordinates

### DIFF
--- a/catalogue.html
+++ b/catalogue.html
@@ -33,6 +33,9 @@
 
     <link rel="stylesheet" href="style.css">
 
+    <!-- Leaflet.js for OpenStreetMap -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-4Y0MJKGDZS"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -80,7 +83,8 @@
     </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
     <script src="shared.js"></script>
-    <script src="catalogue.js"></script> 
+    <script src="catalogue.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -593,6 +593,51 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
         font-size: 1em;
     }
 }
+
+/* Sticker Map Section */
+.sticker-map-section {
+    width: 100%;
+    max-width: 600px;
+    margin-top: calc(var(--spacing-unit) * 3);
+    text-align: left;
+}
+
+.sticker-map-label {
+    font-size: 1.2em;
+    margin-bottom: calc(var(--spacing-unit) * 1.5);
+    color: var(--color-text);
+}
+
+.sticker-map-container {
+    width: 100%;
+    height: 300px;
+    border-radius: var(--border-radius);
+    border: 1px solid var(--color-border);
+    overflow: hidden;
+    z-index: 1;
+}
+
+/* Leaflet popup styling to match site design */
+.leaflet-popup-content-wrapper {
+    border-radius: var(--border-radius);
+    font-family: var(--font-family);
+}
+
+.leaflet-popup-content {
+    margin: 10px 14px;
+    font-size: 0.95em;
+    color: var(--color-text);
+}
+
+@media (max-width: 600px) {
+    .sticker-map-container {
+        height: 250px;
+    }
+
+    .sticker-map-label {
+        font-size: 1em;
+    }
+}
 /* ------------------------------ */
 /* Responsiveness                 */
 /* ------------------------------ */


### PR DESCRIPTION
- Add Leaflet.js library for map rendering (CDN)
- Show interactive map on sticker detail page when latitude/longitude available
- Map displays marker at sticker location with popup showing location name
- Scroll zoom disabled by default, enabled on click for better UX
- Responsive design: 300px height on desktop, 250px on mobile
- Styled to match site design (border-radius, fonts, colors)