### PR TITLE
Fix button sizing and map layout consistency

### DIFF
--- a/catalogue.js
+++ b/catalogue.js
@@ -738,7 +738,9 @@ async function loadStickerDetails(stickerId) {
                 <div class="sticker-map-section">
                     <p class="sticker-map-label"><strong>📍 Found Location</strong></p>
                     <div id="sticker-map" class="sticker-map-container"></div>
-                    <a href="/map.html" class="btn btn-secondary view-map-btn">View Full Map</a>
+                    <div class="view-map-btn-container">
+                        <a href="/map.html" class="btn btn-secondary">View Full Map</a>
+                    </div>
                 </div>
             ` : '';
 

--- a/style.css
+++ b/style.css
@@ -102,7 +102,7 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
 #landing-page button.google-login { display: inline-flex; justify-content: center; align-items: center; width: 90%; max-width: 320px; }
 
 /* --- Difficulty Selection --- */
-#difficulty-selection { max-width: 450px; margin-left: auto; margin-right: auto; }
+#difficulty-selection { max-width: 320px; margin-left: auto; margin-right: auto; }
 .difficulty-options-container { display: flex; flex-direction: column; align-items: center; gap: calc(var(--spacing-unit) * 2.5); margin-top: calc(var(--spacing-unit) * 2); }
 .difficulty-option { width: 100%; text-align: center; }
 .difficulty-option button.difficulty-button { width: 100%; display: block; margin-bottom: calc(var(--spacing-unit) * 0.75); }
@@ -680,7 +680,7 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
 }
 
 /* Global Map Page Styles */
-.map-page-container {
+.container.map-page-container {
     text-align: center;
     max-width: 1200px;
 }
@@ -716,14 +716,38 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
 }
 
 /* View map button on sticker detail page and catalogue */
-.view-map-btn {
-    display: inline-block;
-    margin-top: calc(var(--spacing-unit) * 2);
+.view-map-btn-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    max-width: 320px;
+    margin: calc(var(--spacing-unit) * 2) auto 0 auto;
+}
+
+.view-map-btn-container .btn {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
 }
 
 .catalogue-map-btn-container {
-    text-align: center;
-    margin-bottom: calc(var(--spacing-unit) * 3);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    max-width: 320px;
+    margin: 0 auto calc(var(--spacing-unit) * 3) auto;
+}
+
+.catalogue-map-btn-container .btn {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
 }
 
 @media (max-width: 600px) {
@@ -731,7 +755,7 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
         height: 400px;
     }
 
-    .map-page-container {
+    .container.map-page-container {
         max-width: 100%;
     }
 


### PR DESCRIPTION
- Make quiz page difficulty buttons same width as home page (320px max)
- Style View Full Map button same as View Catalogue (320px centered)
- Fix global map to be landscape on desktop (1200px max-width, higher CSS specificity)
- Center-align buttons in containers on sticker detail and catalogue pages