### PR TITLE
Fix map page container width on desktop

### DIFF
--- a/style.css
+++ b/style.css
@@ -682,7 +682,8 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
 /* Global Map Page Styles */
 .container.map-page-container {
     text-align: center;
-    max-width: 1200px;
+    max-width: 1200px !important;
+    width: 100%;
 }
 
 .map-page-container h1 {


### PR DESCRIPTION
Add !important to max-width override and explicit width: 100% to ensure the map page container expands to 1200px on desktop instead of being constrained to the default 800px.