### PR TITLE
Fix leaderboard display, quiz reset, and map popup behavior

### DIFF
--- a/catalogue.js
+++ b/catalogue.js
@@ -1132,8 +1132,11 @@ function initializeStickerMap(latitude, longitude, clubName, currentStickerId, n
 
                 nearbyMarker.bindPopup(popupContent);
 
-                // Show popup on hover
+                // Show popup on hover (desktop) and click (mobile)
                 nearbyMarker.on('mouseover', function() {
+                    this.openPopup();
+                });
+                nearbyMarker.on('click', function() {
                     this.openPopup();
                 });
             }

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -197,12 +197,13 @@ function displayLeaderboard(data) {
 
     // If user is not in top 5 but has a score, show their position
     if (userPosition > DISPLAY_LIMIT && userEntry) {
-        // Add separator
-        const separatorLi = document.createElement('li');
-        separatorLi.style.listStyle = 'none';
-        separatorLi.style.marginLeft = '-20px';
-        separatorLi.textContent = '...';
-        leaderboardListElement.appendChild(separatorLi);
+        // Add separator (not as list item to avoid numbering)
+        const separatorDiv = document.createElement('div');
+        separatorDiv.style.textAlign = 'left';
+        separatorDiv.style.paddingLeft = '0';
+        separatorDiv.style.margin = '8px 0';
+        separatorDiv.textContent = '...';
+        leaderboardListElement.appendChild(separatorDiv);
 
         // Add user's entry with their actual position
         const userLi = document.createElement('li');

--- a/map.js
+++ b/map.js
@@ -145,8 +145,11 @@ async function initializeGlobalMap() {
 
                 marker.bindPopup(popupContent);
 
-                // Show popup on hover
+                // Show popup on hover (desktop) and click (mobile)
                 marker.on('mouseover', function() {
+                    this.openPopup();
+                });
+                marker.on('click', function() {
                     this.openPopup();
                 });
             }

--- a/script.js
+++ b/script.js
@@ -842,6 +842,12 @@ async function startGame() {
     if (optionsContainerElement) optionsContainerElement.innerHTML = '';
     if (landingPageElement) landingPageElement.style.display = 'none';
 
+    // Clear previous sticker image to start with clean state
+    if (stickerImageElement) {
+        stickerImageElement.src = '';
+        stickerImageElement.alt = '';
+    }
+
     if (preloadingPromise) {
         const questionData = await preloadingPromise;
         preloadingPromise = null;


### PR DESCRIPTION
- Leaderboard: Use div for '...' separator to avoid numbering, show correct user position
- Quiz: Clear previous sticker image when starting new game
- Maps: Open popup on first click/tap (mobile support) in map.js and catalogue.js