### PR TITLE
Add statistics page with sticker growth chart and top clubs/countries

### DIFF
--- a/catalogue.js
+++ b/catalogue.js
@@ -398,9 +398,10 @@ async function loadContinentsAndCountries() {
         // Add statistics block
         let statsHtml = `
             <div class="catalogue-stats">
-                <p><strong>Countries:</strong> ${totalCountriesInCatalogue}</p>
-                <p><strong>Clubs:</strong> ${clubs.length}</p>
                 <p><strong>Stickers:</strong> ${totalStickers}</p>
+                <p><strong>Clubs:</strong> ${clubs.length}</p>
+                <p><strong>Countries:</strong> ${totalCountriesInCatalogue}</p>
+                <a href="/stickerstat.html" class="stats-more-link">View more stats</a>
             </div>
             <div class="catalogue-map-btn-container">
                 <a href="/map.html" class="btn btn-secondary">View Full Map</a>

--- a/stickerstat.html
+++ b/stickerstat.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Statistics - StickerHunt</title>
+    <link rel="icon" href="favicon.ico" type="image/x-icon">
+
+    <!-- SEO Meta Tags -->
+    <meta name="description" content="Explore detailed statistics about our football sticker database. View sticker growth trends, top clubs by sticker count, and countries with most clubs.">
+    <meta name="keywords" content="football stickers, statistics, panini, sticker database, clubs, countries">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://stickerhunt.club/stickerstat.html">
+    <meta property="og:title" content="Statistics - StickerHunt">
+    <meta property="og:description" content="Explore detailed statistics about our football sticker database. View sticker growth trends, top clubs by sticker count, and countries with most clubs.">
+    <meta property="og:image" content="https://stickerhunt.club/metash.png">
+    <meta property="og:site_name" content="StickerHunt">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://stickerhunt.club/stickerstat.html">
+    <meta property="twitter:title" content="Statistics - StickerHunt">
+    <meta property="twitter:description" content="Explore detailed statistics about our football sticker database. View sticker growth trends, top clubs by sticker count, and countries with most clubs.">
+    <meta property="twitter:image" content="https://stickerhunt.club/metash.png">
+    <meta property="twitter:site" content="@StickerHunting">
+    <meta property="twitter:creator" content="@StickerHunting">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="style.css">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4Y0MJKGDZS"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-4Y0MJKGDZS');
+    </script>
+</head>
+<body>
+    <header class="app-header">
+        <div class="logo-container">
+           <a href="/index.html"><img src="/logo.png" alt="StickerHunt Logo" id="app-logo"></a>
+        </div>
+        <div id="auth-section">
+             <button id="login-button" class="btn btn-primary google-login" style="display: none;">
+                 <span>Sign in with Google</span>
+             </button>
+             <div id="user-status" style="display: none;">
+                 <strong id="user-nickname" title="Click to edit nickname">Loading...</strong>
+                 <button id="logout-button" class="btn-link">Logout</button>
+                 <form id="edit-nickname-form" style="display: none;">
+                     <input type="text" id="nickname-input" placeholder="Enter new nickname" required minlength="3" maxlength="25" size="15">
+                     <button type="submit" class="btn btn-primary">Save</button>
+                     <button type="button" id="cancel-edit-nickname-button" class="btn btn-secondary">Cancel</button>
+                 </form>
+             </div>
+         </div>
+    </header>
+
+    <main class="container" id="stats-container">
+        <h1>Statistics</h1>
+
+        <section class="stats-section" id="stickers-section">
+            <h2>Stickers (<span id="total-stickers-count">0</span>)</h2>
+            <div class="chart-container">
+                <canvas id="stickers-chart"></canvas>
+            </div>
+        </section>
+
+        <section class="stats-section" id="clubs-section">
+            <h2>Clubs (<span id="total-clubs-count">0</span>)</h2>
+            <p class="stats-section-subtitle">Top 20 clubs by number of stickers</p>
+            <div id="clubs-table-container">
+                <p>Loading...</p>
+            </div>
+        </section>
+
+        <section class="stats-section" id="countries-section">
+            <h2>Countries (<span id="total-countries-count">0</span>)</h2>
+            <p class="stats-section-subtitle">Top 20 countries by number of clubs</p>
+            <div id="countries-table-container">
+                <p>Loading...</p>
+            </div>
+        </section>
+
+        <div class="home-actions stats-actions">
+            <a href="/quiz.html" class="btn btn-primary btn-large">Play Quiz</a>
+            <a href="/catalogue.html" class="btn btn-secondary btn-large">View Catalogue</a>
+        </div>
+    </main>
+
+    <footer class="app-footer">
+        <p>
+            <a href="/about.html">About</a> |
+            <a href="/terms.html">Terms of Service</a> |
+            <a href="/privacy.html">Privacy Policy</a>
+        </p>
+        <p>StickerHunt &copy; 2025</p>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+    <script src="shared.js"></script>
+    <script src="stickerstat.js"></script>
+</body>
+</html>

--- a/stickerstat.js
+++ b/stickerstat.js
@@ -1,0 +1,586 @@
+// stickerstat.js - Statistics page functionality
+// Uses SharedUtils from shared.js for common functionality
+
+let supabaseClient;
+
+// Auth state
+let currentUser = null;
+let currentUserProfile = null;
+
+// Edit nickname form elements
+let editNicknameForm;
+let nicknameInputElement;
+let cancelEditNicknameButton;
+
+// Chart instance
+let stickersChart = null;
+
+// Country code to details mapping (same as catalogue.js)
+const countryCodeToDetails = {
+    "AFG": { name: "Afghanistan" }, "ALB": { name: "Albania" }, "DZA": { name: "Algeria" },
+    "AND": { name: "Andorra" }, "AGO": { name: "Angola" }, "ARG": { name: "Argentina" },
+    "ARM": { name: "Armenia" }, "AUS": { name: "Australia" }, "AUT": { name: "Austria" },
+    "AZE": { name: "Azerbaijan" }, "BHS": { name: "Bahamas" }, "BHR": { name: "Bahrain" },
+    "BGD": { name: "Bangladesh" }, "BLR": { name: "Belarus" }, "BEL": { name: "Belgium" },
+    "BLZ": { name: "Belize" }, "BEN": { name: "Benin" }, "BOL": { name: "Bolivia" },
+    "BIH": { name: "Bosnia and Herzegovina" }, "BWA": { name: "Botswana" }, "BRA": { name: "Brazil" },
+    "BGR": { name: "Bulgaria" }, "BFA": { name: "Burkina Faso" }, "KHM": { name: "Cambodia" },
+    "CMR": { name: "Cameroon" }, "CAN": { name: "Canada" }, "CPV": { name: "Cape Verde" },
+    "CAF": { name: "Central African Republic" }, "TCD": { name: "Chad" }, "CHL": { name: "Chile" },
+    "CHN": { name: "China" }, "COL": { name: "Colombia" }, "COG": { name: "Congo" },
+    "CRI": { name: "Costa Rica" }, "HRV": { name: "Croatia" }, "CUB": { name: "Cuba" },
+    "CYP": { name: "Cyprus" }, "CZE": { name: "Czech Republic" }, "DNK": { name: "Denmark" },
+    "DJI": { name: "Djibouti" }, "DOM": { name: "Dominican Republic" }, "ECU": { name: "Ecuador" },
+    "EGY": { name: "Egypt" }, "SLV": { name: "El Salvador" }, "GNQ": { name: "Equatorial Guinea" },
+    "EST": { name: "Estonia" }, "ETH": { name: "Ethiopia" }, "FJI": { name: "Fiji" },
+    "FIN": { name: "Finland" }, "FRA": { name: "France" }, "GAB": { name: "Gabon" },
+    "GMB": { name: "Gambia" }, "GEO": { name: "Georgia" }, "DEU": { name: "Germany" },
+    "GHA": { name: "Ghana" }, "GRC": { name: "Greece" }, "GTM": { name: "Guatemala" },
+    "GIN": { name: "Guinea" }, "HTI": { name: "Haiti" }, "HND": { name: "Honduras" },
+    "HUN": { name: "Hungary" }, "ISL": { name: "Iceland" }, "IND": { name: "India" },
+    "IDN": { name: "Indonesia" }, "IRN": { name: "Iran" }, "IRQ": { name: "Iraq" },
+    "IRL": { name: "Ireland" }, "ISR": { name: "Israel" }, "ITA": { name: "Italy" },
+    "CIV": { name: "Ivory Coast" }, "JAM": { name: "Jamaica" }, "JPN": { name: "Japan" },
+    "JOR": { name: "Jordan" }, "KAZ": { name: "Kazakhstan" }, "KEN": { name: "Kenya" },
+    "KWT": { name: "Kuwait" }, "KGZ": { name: "Kyrgyzstan" }, "LVA": { name: "Latvia" },
+    "LBN": { name: "Lebanon" }, "LBR": { name: "Liberia" }, "LBY": { name: "Libya" },
+    "LIE": { name: "Liechtenstein" }, "LTU": { name: "Lithuania" }, "LUX": { name: "Luxembourg" },
+    "MKD": { name: "North Macedonia" }, "MDG": { name: "Madagascar" }, "MWI": { name: "Malawi" },
+    "MYS": { name: "Malaysia" }, "MLI": { name: "Mali" }, "MLT": { name: "Malta" },
+    "MRT": { name: "Mauritania" }, "MEX": { name: "Mexico" }, "MDA": { name: "Moldova" },
+    "MCO": { name: "Monaco" }, "MNG": { name: "Mongolia" }, "MNE": { name: "Montenegro" },
+    "MAR": { name: "Morocco" }, "MOZ": { name: "Mozambique" }, "NPL": { name: "Nepal" },
+    "NLD": { name: "Netherlands" }, "NZL": { name: "New Zealand" }, "NIC": { name: "Nicaragua" },
+    "NER": { name: "Niger" }, "NGA": { name: "Nigeria" }, "PRK": { name: "North Korea" },
+    "NOR": { name: "Norway" }, "OMN": { name: "Oman" }, "PAK": { name: "Pakistan" },
+    "PAN": { name: "Panama" }, "PNG": { name: "Papua New Guinea" }, "PRY": { name: "Paraguay" },
+    "PER": { name: "Peru" }, "PHL": { name: "Philippines" }, "POL": { name: "Poland" },
+    "PRT": { name: "Portugal" }, "QAT": { name: "Qatar" }, "ROU": { name: "Romania" },
+    "RUS": { name: "Russia" }, "RWA": { name: "Rwanda" }, "SAU": { name: "Saudi Arabia" },
+    "SEN": { name: "Senegal" }, "SRB": { name: "Serbia" }, "SLE": { name: "Sierra Leone" },
+    "SGP": { name: "Singapore" }, "SVK": { name: "Slovakia" }, "SVN": { name: "Slovenia" },
+    "SOM": { name: "Somalia" }, "ZAF": { name: "South Africa" }, "KOR": { name: "South Korea" },
+    "ESP": { name: "Spain" }, "LKA": { name: "Sri Lanka" }, "SDN": { name: "Sudan" },
+    "SWE": { name: "Sweden" }, "CHE": { name: "Switzerland" }, "SYR": { name: "Syria" },
+    "TWN": { name: "Taiwan" }, "TZA": { name: "Tanzania" }, "THA": { name: "Thailand" },
+    "TGO": { name: "Togo" }, "TUN": { name: "Tunisia" }, "TUR": { name: "Turkey" },
+    "UGA": { name: "Uganda" }, "UKR": { name: "Ukraine" }, "ARE": { name: "United Arab Emirates" },
+    "GBR": { name: "United Kingdom" }, "USA": { name: "United States" }, "URY": { name: "Uruguay" },
+    "UZB": { name: "Uzbekistan" }, "VEN": { name: "Venezuela" }, "VNM": { name: "Vietnam" },
+    "YEM": { name: "Yemen" }, "ZMB": { name: "Zambia" }, "ZWE": { name: "Zimbabwe" },
+    "ENG": { name: "England" }, "SCO": { name: "Scotland" }, "WLS": { name: "Wales" },
+    "NIR": { name: "Northern Ireland" }
+};
+
+const countryCodeToFlagEmoji = {
+    "AFG": "🇦🇫", "ALB": "🇦🇱", "DZA": "🇩🇿", "AND": "🇦🇩", "AGO": "🇦🇴", "ARG": "🇦🇷", "ARM": "🇦🇲",
+    "AUS": "🇦🇺", "AUT": "🇦🇹", "AZE": "🇦🇿", "BHS": "🇧🇸", "BHR": "🇧🇭", "BGD": "🇧🇩", "BLR": "🇧🇾",
+    "BEL": "🇧🇪", "BLZ": "🇧🇿", "BEN": "🇧🇯", "BOL": "🇧🇴", "BIH": "🇧🇦", "BWA": "🇧🇼", "BRA": "🇧🇷",
+    "BGR": "🇧🇬", "BFA": "🇧🇫", "KHM": "🇰🇭", "CMR": "🇨🇲", "CAN": "🇨🇦", "CPV": "🇨🇻", "CAF": "🇨🇫",
+    "TCD": "🇹🇩", "CHL": "🇨🇱", "CHN": "🇨🇳", "COL": "🇨🇴", "COG": "🇨🇬", "CRI": "🇨🇷", "HRV": "🇭🇷",
+    "CUB": "🇨🇺", "CYP": "🇨🇾", "CZE": "🇨🇿", "DNK": "🇩🇰", "DJI": "🇩🇯", "DOM": "🇩🇴", "ECU": "🇪🇨",
+    "EGY": "🇪🇬", "SLV": "🇸🇻", "GNQ": "🇬🇶", "EST": "🇪🇪", "ETH": "🇪🇹", "FJI": "🇫🇯", "FIN": "🇫🇮",
+    "FRA": "🇫🇷", "GAB": "🇬🇦", "GMB": "🇬🇲", "GEO": "🇬🇪", "DEU": "🇩🇪", "GHA": "🇬🇭", "GRC": "🇬🇷",
+    "GTM": "🇬🇹", "GIN": "🇬🇳", "HTI": "🇭🇹", "HND": "🇭🇳", "HUN": "🇭🇺", "ISL": "🇮🇸", "IND": "🇮🇳",
+    "IDN": "🇮🇩", "IRN": "🇮🇷", "IRQ": "🇮🇶", "IRL": "🇮🇪", "ISR": "🇮🇱", "ITA": "🇮🇹", "CIV": "🇨🇮",
+    "JAM": "🇯🇲", "JPN": "🇯🇵", "JOR": "🇯🇴", "KAZ": "🇰🇿", "KEN": "🇰🇪", "KWT": "🇰🇼", "KGZ": "🇰🇬",
+    "LVA": "🇱🇻", "LBN": "🇱🇧", "LBR": "🇱🇷", "LBY": "🇱🇾", "LIE": "🇱🇮", "LTU": "🇱🇹", "LUX": "🇱🇺",
+    "MKD": "🇲🇰", "MDG": "🇲🇬", "MWI": "🇲🇼", "MYS": "🇲🇾", "MLI": "🇲🇱", "MLT": "🇲🇹", "MRT": "🇲🇷",
+    "MEX": "🇲🇽", "MDA": "🇲🇩", "MCO": "🇲🇨", "MNG": "🇲🇳", "MNE": "🇲🇪", "MAR": "🇲🇦", "MOZ": "🇲🇿",
+    "NPL": "🇳🇵", "NLD": "🇳🇱", "NZL": "🇳🇿", "NIC": "🇳🇮", "NER": "🇳🇪", "NGA": "🇳🇬", "PRK": "🇰🇵",
+    "NOR": "🇳🇴", "OMN": "🇴🇲", "PAK": "🇵🇰", "PAN": "🇵🇦", "PNG": "🇵🇬", "PRY": "🇵🇾", "PER": "🇵🇪",
+    "PHL": "🇵🇭", "POL": "🇵🇱", "PRT": "🇵🇹", "QAT": "🇶🇦", "ROU": "🇷🇴", "RUS": "🇷🇺", "RWA": "🇷🇼",
+    "SAU": "🇸🇦", "SEN": "🇸🇳", "SRB": "🇷🇸", "SLE": "🇸🇱", "SGP": "🇸🇬", "SVK": "🇸🇰", "SVN": "🇸🇮",
+    "SOM": "🇸🇴", "ZAF": "🇿🇦", "KOR": "🇰🇷", "ESP": "🇪🇸", "LKA": "🇱🇰", "SDN": "🇸🇩", "SWE": "🇸🇪",
+    "CHE": "🇨🇭", "SYR": "🇸🇾", "TWN": "🇹🇼", "TZA": "🇹🇿", "THA": "🇹🇭", "TGO": "🇹🇬", "TUN": "🇹🇳",
+    "TUR": "🇹🇷", "UGA": "🇺🇬", "UKR": "🇺🇦", "ARE": "🇦🇪", "GBR": "🇬🇧", "USA": "🇺🇸", "URY": "🇺🇾",
+    "UZB": "🇺🇿", "VEN": "🇻🇪", "VNM": "🇻🇳", "YEM": "🇾🇪", "ZMB": "🇿🇲", "ZWE": "🇿🇼",
+    "ENG": "🏴󠁧󠁢󠁥󠁮󠁧󠁿", "SCO": "🏴󠁧󠁢󠁳󠁣󠁴󠁿", "WLS": "🏴󠁧󠁢󠁷󠁬󠁳󠁿", "NIR": "🇬🇧"
+};
+
+// Initialize Supabase Client
+if (typeof SharedUtils === 'undefined') {
+    console.error('Error: SharedUtils not loaded. Make sure shared.js is included before stickerstat.js');
+} else {
+    supabaseClient = SharedUtils.initSupabaseClient();
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+    if (supabaseClient) {
+        // Setup auth
+        setupAuth();
+
+        // Initialize nickname editing elements
+        editNicknameForm = document.getElementById('edit-nickname-form');
+        nicknameInputElement = document.getElementById('nickname-input');
+        cancelEditNicknameButton = document.getElementById('cancel-edit-nickname-button');
+        setupNicknameEditing();
+
+        // Load statistics
+        await loadAllStatistics();
+    } else {
+        console.error('Supabase client failed to initialize.');
+    }
+});
+
+async function loadAllStatistics() {
+    // Load all data in parallel
+    const [stickersData, clubsData, countriesData] = await Promise.all([
+        loadStickersGrowth(),
+        loadTopClubs(),
+        loadTopCountries()
+    ]);
+}
+
+// ========== STICKERS GROWTH CHART ==========
+
+async function loadStickersGrowth() {
+    const chartCanvas = document.getElementById('stickers-chart');
+    const totalStickersEl = document.getElementById('total-stickers-count');
+
+    if (!supabaseClient || !chartCanvas) return;
+
+    try {
+        // Fetch all stickers with their found date
+        const { data: stickers, error } = await supabaseClient
+            .from('stickers')
+            .select('id, found')
+            .order('found', { ascending: true });
+
+        if (error) throw error;
+
+        // Update total count
+        if (totalStickersEl) {
+            totalStickersEl.textContent = stickers.length;
+        }
+
+        // Group stickers by date and calculate cumulative count
+        const dateCountMap = new Map();
+        let cumulative = 0;
+
+        stickers.forEach(sticker => {
+            if (sticker.found) {
+                const dateStr = sticker.found.split('T')[0]; // Get just the date part
+                cumulative++;
+                dateCountMap.set(dateStr, cumulative);
+            }
+        });
+
+        // Convert to arrays for Chart.js
+        const labels = Array.from(dateCountMap.keys());
+        const data = Array.from(dateCountMap.values());
+
+        // Create chart
+        if (stickersChart) {
+            stickersChart.destroy();
+        }
+
+        const ctx = chartCanvas.getContext('2d');
+        stickersChart = new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [{
+                    label: 'Total Stickers',
+                    data: data,
+                    borderColor: '#FFC107',
+                    backgroundColor: 'rgba(255, 193, 7, 0.1)',
+                    borderWidth: 2,
+                    fill: true,
+                    tension: 0.3,
+                    pointRadius: 0,
+                    pointHoverRadius: 4
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: {
+                        display: false
+                    },
+                    tooltip: {
+                        mode: 'index',
+                        intersect: false,
+                        callbacks: {
+                            title: function(context) {
+                                const date = new Date(context[0].label);
+                                return date.toLocaleDateString('en-US', {
+                                    year: 'numeric',
+                                    month: 'short',
+                                    day: 'numeric'
+                                });
+                            }
+                        }
+                    }
+                },
+                scales: {
+                    x: {
+                        display: true,
+                        grid: {
+                            display: false
+                        },
+                        ticks: {
+                            maxTicksLimit: 6,
+                            callback: function(value, index) {
+                                const label = this.getLabelForValue(value);
+                                const date = new Date(label);
+                                return date.toLocaleDateString('en-US', { month: 'short', year: '2-digit' });
+                            }
+                        }
+                    },
+                    y: {
+                        display: true,
+                        beginAtZero: true,
+                        grid: {
+                            color: 'rgba(0, 0, 0, 0.05)'
+                        }
+                    }
+                },
+                interaction: {
+                    mode: 'nearest',
+                    axis: 'x',
+                    intersect: false
+                }
+            }
+        });
+
+    } catch (error) {
+        console.error('Error loading stickers growth:', error);
+        chartCanvas.parentElement.innerHTML = '<p>Could not load chart data.</p>';
+    }
+}
+
+// ========== TOP CLUBS ==========
+
+async function loadTopClubs() {
+    const container = document.getElementById('clubs-table-container');
+    const totalClubsEl = document.getElementById('total-clubs-count');
+
+    if (!supabaseClient || !container) return;
+
+    try {
+        // Fetch all clubs
+        const { data: clubs, error: clubsError } = await supabaseClient
+            .from('clubs')
+            .select('id, name');
+
+        if (clubsError) throw clubsError;
+
+        // Update total count
+        if (totalClubsEl) {
+            totalClubsEl.textContent = clubs.length;
+        }
+
+        // Fetch all stickers to count per club
+        const { data: stickers, error: stickersError } = await supabaseClient
+            .from('stickers')
+            .select('club_id');
+
+        if (stickersError) throw stickersError;
+
+        // Count stickers per club
+        const stickerCountByClub = {};
+        stickers.forEach(sticker => {
+            if (sticker.club_id) {
+                stickerCountByClub[sticker.club_id] = (stickerCountByClub[sticker.club_id] || 0) + 1;
+            }
+        });
+
+        // Create club data with sticker counts
+        const clubsWithCounts = clubs.map(club => ({
+            id: club.id,
+            name: club.name,
+            stickerCount: stickerCountByClub[club.id] || 0
+        }));
+
+        // Sort by sticker count and take top 20
+        const topClubs = clubsWithCounts
+            .sort((a, b) => b.stickerCount - a.stickerCount)
+            .slice(0, 20);
+
+        // Generate table HTML
+        let tableHtml = '<table class="stats-table">';
+        topClubs.forEach((club, index) => {
+            tableHtml += `
+                <tr>
+                    <td class="stats-rank">${index + 1}</td>
+                    <td class="stats-name"><a href="/catalogue.html?club_id=${club.id}">${club.name}</a></td>
+                    <td class="stats-count">${club.stickerCount}</td>
+                </tr>
+            `;
+        });
+        tableHtml += '</table>';
+
+        container.innerHTML = tableHtml;
+
+    } catch (error) {
+        console.error('Error loading top clubs:', error);
+        container.innerHTML = '<p>Could not load club data.</p>';
+    }
+}
+
+// ========== TOP COUNTRIES ==========
+
+async function loadTopCountries() {
+    const container = document.getElementById('countries-table-container');
+    const totalCountriesEl = document.getElementById('total-countries-count');
+
+    if (!supabaseClient || !container) return;
+
+    try {
+        // Fetch all clubs with their countries
+        const { data: clubs, error } = await supabaseClient
+            .from('clubs')
+            .select('country');
+
+        if (error) throw error;
+
+        // Count clubs per country
+        const clubCountByCountry = {};
+        clubs.forEach(club => {
+            if (club.country) {
+                const countryCode = club.country.toUpperCase();
+                clubCountByCountry[countryCode] = (clubCountByCountry[countryCode] || 0) + 1;
+            }
+        });
+
+        // Get unique countries count
+        const uniqueCountries = Object.keys(clubCountByCountry).length;
+        if (totalCountriesEl) {
+            totalCountriesEl.textContent = uniqueCountries;
+        }
+
+        // Create country data with club counts
+        const countriesWithCounts = Object.entries(clubCountByCountry).map(([code, count]) => ({
+            code: code,
+            name: countryCodeToDetails[code]?.name || code,
+            flag: countryCodeToFlagEmoji[code] || '🏳️',
+            clubCount: count
+        }));
+
+        // Sort by club count and take top 20
+        const topCountries = countriesWithCounts
+            .sort((a, b) => b.clubCount - a.clubCount)
+            .slice(0, 20);
+
+        // Generate table HTML
+        let tableHtml = '<table class="stats-table">';
+        topCountries.forEach((country, index) => {
+            tableHtml += `
+                <tr>
+                    <td class="stats-rank">${index + 1}</td>
+                    <td class="stats-name"><span class="flag-emoji">${country.flag}</span> <a href="/catalogue.html?country=${country.code}">${country.name}</a></td>
+                    <td class="stats-count">${country.clubCount}</td>
+                </tr>
+            `;
+        });
+        tableHtml += '</table>';
+
+        container.innerHTML = tableHtml;
+
+    } catch (error) {
+        console.error('Error loading top countries:', error);
+        container.innerHTML = '<p>Could not load country data.</p>';
+    }
+}
+
+// ========== AUTH FUNCTIONS ==========
+
+async function loadAndSetUserProfile(user) {
+    if (!supabaseClient || !user) return;
+
+    const profile = await SharedUtils.loadUserProfile(supabaseClient, user);
+    if (profile) {
+        currentUserProfile = profile;
+        SharedUtils.cacheUserProfile(profile);
+    }
+}
+
+function updateAuthUI(user) {
+    const loginButton = document.getElementById('login-button');
+    const userStatusElement = document.getElementById('user-status');
+    const userNicknameElement = document.getElementById('user-nickname');
+
+    if (!loginButton || !userStatusElement || !userNicknameElement) return;
+
+    if (user) {
+        const displayName = currentUserProfile?.username || 'Loading...';
+        userNicknameElement.textContent = SharedUtils.truncateString(displayName);
+        loginButton.style.display = 'none';
+        userStatusElement.style.display = 'flex';
+    } else {
+        loginButton.style.display = 'none';
+        userStatusElement.style.display = 'none';
+    }
+}
+
+function handleLoginClick() {
+    if (!supabaseClient) return;
+    SharedUtils.loginWithGoogle(supabaseClient, '/stickerstat.html').then(result => {
+        if (result.error) {
+            alert('Login failed. Please try again.');
+        }
+    });
+}
+
+async function handleLogoutClick() {
+    if (!supabaseClient) return;
+
+    const result = await SharedUtils.logout(supabaseClient, currentUser?.id);
+    if (result.error) {
+        alert('Logout failed. Please try again.');
+    } else {
+        window.location.reload();
+    }
+}
+
+function setupAuth() {
+    if (!supabaseClient) return;
+
+    const loginButton = document.getElementById('login-button');
+    const logoutButton = document.getElementById('logout-button');
+
+    if (loginButton) {
+        loginButton.addEventListener('click', handleLoginClick);
+    }
+    if (logoutButton) {
+        logoutButton.addEventListener('click', handleLogoutClick);
+    }
+
+    supabaseClient.auth.getSession().then(async ({ data: { session }, error }) => {
+        if (error) {
+            console.error('Error getting session:', error);
+            updateAuthUI(null);
+            setupAuthStateListener();
+            return;
+        }
+
+        const user = session?.user ?? null;
+
+        if (user) {
+            currentUser = user;
+
+            const cachedProfile = SharedUtils.loadCachedProfile(user.id);
+            if (cachedProfile) {
+                currentUserProfile = cachedProfile;
+                updateAuthUI(user);
+            }
+
+            await loadAndSetUserProfile(user);
+            updateAuthUI(user);
+        } else {
+            updateAuthUI(null);
+        }
+
+        setupAuthStateListener();
+    });
+}
+
+function setupAuthStateListener() {
+    if (!supabaseClient) return;
+
+    supabaseClient.auth.onAuthStateChange(async (event, session) => {
+        if (event === 'INITIAL_SESSION') {
+            return;
+        }
+
+        const user = session?.user ?? null;
+
+        if (event === 'SIGNED_OUT') {
+            if (currentUser) {
+                SharedUtils.clearCachedProfile(currentUser.id);
+            }
+            currentUser = null;
+            currentUserProfile = null;
+            updateAuthUI(null);
+            return;
+        }
+
+        if (event === 'SIGNED_IN' && user) {
+            if (!currentUser || currentUser.id !== user.id) {
+                currentUser = user;
+                const cachedProfile = SharedUtils.loadCachedProfile(user.id);
+                if (cachedProfile) {
+                    currentUserProfile = cachedProfile;
+                }
+                updateAuthUI(user);
+                await loadAndSetUserProfile(user);
+                updateAuthUI(user);
+            }
+        }
+
+        if (event === 'TOKEN_REFRESHED' && user) {
+            currentUser = user;
+        }
+    });
+}
+
+// ========== NICKNAME EDITING FUNCTIONS ==========
+
+function setupNicknameEditing() {
+    const userNicknameElement = document.getElementById('user-nickname');
+    if (!userNicknameElement) return;
+
+    userNicknameElement.addEventListener('click', showNicknameEditForm);
+
+    if (editNicknameForm) {
+        editNicknameForm.addEventListener('submit', handleNicknameSave);
+    }
+    if (cancelEditNicknameButton) {
+        cancelEditNicknameButton.addEventListener('click', hideNicknameEditForm);
+    }
+}
+
+function showNicknameEditForm() {
+    if (!currentUserProfile) {
+        alert('Please wait for your profile to load...');
+        return;
+    }
+
+    if (!editNicknameForm || !nicknameInputElement) return;
+
+    nicknameInputElement.value = currentUserProfile.username || '';
+    editNicknameForm.style.display = 'block';
+    nicknameInputElement.focus();
+    nicknameInputElement.select();
+}
+
+function hideNicknameEditForm() {
+    if (!editNicknameForm || !nicknameInputElement) return;
+    editNicknameForm.style.display = 'none';
+    nicknameInputElement.value = '';
+}
+
+async function handleNicknameSave(event) {
+    event.preventDefault();
+
+    if (!currentUser || !nicknameInputElement || !supabaseClient || !currentUserProfile) {
+        alert('Cannot save nickname');
+        return;
+    }
+
+    const newNickname = nicknameInputElement.value.trim();
+
+    if (newNickname === currentUserProfile.username) {
+        hideNicknameEditForm();
+        return;
+    }
+
+    const result = await SharedUtils.updateNickname(supabaseClient, currentUser.id, newNickname);
+
+    if (result.error) {
+        alert(`Update failed: ${result.error.message}`);
+    } else {
+        currentUserProfile.username = result.data.username;
+        SharedUtils.cacheUserProfile(currentUserProfile);
+
+        const userNicknameElement = document.getElementById('user-nickname');
+        if (userNicknameElement) {
+            userNicknameElement.textContent = SharedUtils.truncateString(result.data.username);
+        }
+
+        hideNicknameEditForm();
+        alert('Nickname updated successfully!');
+    }
+}

--- a/style.css
+++ b/style.css
@@ -1019,3 +1019,161 @@ body.home-page #app-logo {
     from { opacity: 0; transform: scale(0.98); }
     to { opacity: 1; transform: scale(1); }
 }
+
+/* ------------------------------ */
+/* Statistics Page Styles         */
+/* ------------------------------ */
+
+/* Stats more link in catalogue */
+.stats-more-link {
+    display: inline-block;
+    margin-top: calc(var(--spacing-unit) * 1.5);
+    color: var(--color-info-text);
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 0.95em;
+}
+
+@media (hover: hover) {
+    .stats-more-link:hover {
+        color: var(--color-link);
+        text-decoration: underline;
+    }
+}
+
+/* Stats page container */
+#stats-container {
+    text-align: left;
+    max-width: 800px;
+}
+
+#stats-container > h1 {
+    text-align: center;
+    font-size: 2em;
+    margin-bottom: calc(var(--spacing-unit) * 4);
+}
+
+/* Stats sections */
+.stats-section {
+    margin-bottom: calc(var(--spacing-unit) * 5);
+}
+
+.stats-section h2 {
+    font-size: 1.5em;
+    font-weight: 600;
+    color: var(--color-text);
+    margin-bottom: calc(var(--spacing-unit) * 1.5);
+    padding-bottom: calc(var(--spacing-unit) * 0.5);
+    border-bottom: 1px solid var(--color-border);
+}
+
+.stats-section-subtitle {
+    font-size: 0.95em;
+    color: var(--color-info-text);
+    margin-bottom: calc(var(--spacing-unit) * 2);
+    margin-top: calc(var(--spacing-unit) * -1);
+}
+
+/* Chart container */
+.chart-container {
+    width: 100%;
+    height: 300px;
+    background-color: var(--color-secondary-bg);
+    border-radius: var(--border-radius);
+    padding: calc(var(--spacing-unit) * 2);
+    border: 1px solid var(--color-border);
+}
+
+/* Stats table (borderless) */
+.stats-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 1.05em;
+}
+
+.stats-table tr {
+    border-bottom: 1px solid var(--color-border);
+}
+
+.stats-table tr:last-child {
+    border-bottom: none;
+}
+
+.stats-table td {
+    padding: calc(var(--spacing-unit) * 1.25) calc(var(--spacing-unit) * 0.5);
+    vertical-align: middle;
+}
+
+.stats-table .stats-rank {
+    width: 40px;
+    text-align: right;
+    padding-right: calc(var(--spacing-unit) * 1.5);
+    font-weight: 600;
+    color: var(--color-accent-darker);
+}
+
+.stats-table .stats-name {
+    text-align: left;
+}
+
+.stats-table .stats-name a {
+    color: var(--color-info-text);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+@media (hover: hover) {
+    .stats-table .stats-name a:hover {
+        color: var(--color-link);
+        text-decoration: underline;
+    }
+}
+
+.stats-table .stats-count {
+    width: 60px;
+    text-align: right;
+    color: var(--color-info-text);
+    font-weight: 500;
+}
+
+.stats-table .flag-emoji {
+    margin-right: calc(var(--spacing-unit) * 0.75);
+}
+
+/* Stats actions (buttons at bottom) */
+.stats-actions {
+    margin-top: calc(var(--spacing-unit) * 4);
+    margin-bottom: calc(var(--spacing-unit) * 2);
+}
+
+/* Responsive adjustments for stats page */
+@media (max-width: 600px) {
+    #stats-container > h1 {
+        font-size: 1.6em;
+    }
+
+    .stats-section h2 {
+        font-size: 1.3em;
+    }
+
+    .chart-container {
+        height: 250px;
+        padding: var(--spacing-unit);
+    }
+
+    .stats-table {
+        font-size: 0.95em;
+    }
+
+    .stats-table td {
+        padding: var(--spacing-unit) calc(var(--spacing-unit) * 0.25);
+    }
+
+    .stats-table .stats-rank {
+        width: 30px;
+    }
+
+    .stats-table .stats-count {
+        width: 50px;
+    }
+}


### PR DESCRIPTION
- Reorder stats block in catalogue: Stickers, Clubs, Countries
- Add 'View more stats' link to catalogue stats block
- Create stickerstat.html with Chart.js for sticker growth visualization
- Show top 20 clubs by sticker count with links to catalogue
- Show top 20 countries by club count with flags and links
- Add Play Quiz and View Catalogue buttons at bottom
- Include full auth support with nickname editing