### PR TITLE
Add Google Analytics to all pages and update catalogue title structure

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,6 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>About - StickerHunt</title>
     <link rel="stylesheet" href="style.css">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4Y0MJKGDZS"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-4Y0MJKGDZS');
+    </script>
     <style>
         /* Стилі для контейнера, як на сторінках політик */
         body { padding-top: 20px; padding-bottom: 60px; }

--- a/catalogue.html
+++ b/catalogue.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sticker Catalogue - StickerHunt</title>
+    <title>Sticker Catalogue</title>
     <link rel="icon" href="favicon.ico" type="image/x-icon">
 
     <!-- SEO Meta Tags -->
@@ -13,7 +13,7 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://stickerhunt.club/catalogue.html">
-    <meta property="og:title" content="Sticker Catalogue - StickerHunt">
+    <meta property="og:title" content="Sticker Catalogue">
     <meta property="og:description" content="Browse our comprehensive database of football stickers from clubs around the world. Explore by country, view detailed sticker information, and discover the complete collection.">
     <meta property="og:image" content="https://stickerhunt.club/metash.png">
     <meta property="og:site_name" content="StickerHunt">
@@ -21,7 +21,7 @@
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://stickerhunt.club/catalogue.html">
-    <meta property="twitter:title" content="Sticker Catalogue - StickerHunt">
+    <meta property="twitter:title" content="Sticker Catalogue">
     <meta property="twitter:description" content="Browse our comprehensive database of football stickers from clubs around the world. Explore by country, view detailed sticker information, and discover the complete collection.">
     <meta property="twitter:image" content="https://stickerhunt.club/metash.png">
     <meta property="twitter:site" content="@StickerHunting">

--- a/catalogue.js
+++ b/catalogue.js
@@ -468,7 +468,7 @@ async function loadCountryDetails(countryCode) {
             // Update page title with country name
             const countryInfo = countryCodeToDetails_Generic[countryCode];
             const countryDisplayName = countryInfo ? countryInfo.name : countryCode;
-            document.title = `${countryDisplayName} Clubs - Sticker Catalogue`;
+            document.title = `${countryDisplayName} - Sticker Catalogue`;
 
             // Get all club IDs to fetch sticker counts in one query
             const clubIds = clubsInCountry.map(club => club.id);
@@ -542,7 +542,7 @@ async function loadClubDetails(clubId) {
             const countryDisplayName = countryInfo ? countryInfo.name : clubData.country;
 
             if (mainHeading) mainHeading.textContent = `${clubData.name} - Sticker Gallery`;
-            document.title = `${clubData.name} Sticker Gallery - Sticker Catalogue`;
+            document.title = `${clubData.name} - ${countryDisplayName} - Sticker Catalogue`;
 
             // Update meta keywords from media field
             if (clubData.media) {
@@ -666,7 +666,7 @@ async function loadStickerDetails(stickerId) {
                     countryDisplayNameForBreadcrumb = countryDetail ? countryDetail.name : sticker.clubs.country;
                 }
                 if (mainHeading) mainHeading.textContent = `Sticker #${sticker.id} - ${clubName}`;
-                document.title = `Sticker #${sticker.id} ${clubName} - Sticker Catalogue`;
+                document.title = `Sticker #${sticker.id} - ${clubName} - ${countryDisplayNameForBreadcrumb} - Sticker Catalogue`;
 
                 // Update meta keywords from club media field
                 if (sticker.clubs && sticker.clubs.media) {

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     <link rel="stylesheet" href="style.css">
 
     <!-- Analytics - load after page content -->
-    <script defer src="https://www.googletagmanager.com/gtag/js?id=G-4Y0MJKGDZS"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4Y0MJKGDZS"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}

--- a/privacy.html
+++ b/privacy.html
@@ -5,6 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy - StickerHunt</title>
     <link rel="stylesheet" href="style.css">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4Y0MJKGDZS"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-4Y0MJKGDZS');
+    </script>
     <style>
         /* Додаткові стилі для цих сторінок */
         body { padding-top: 20px; padding-bottom: 60px; } /* Відступи */

--- a/terms.html
+++ b/terms.html
@@ -5,6 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Terms of Service - StickerHunt</title>
     <link rel="stylesheet" href="style.css">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4Y0MJKGDZS"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-4Y0MJKGDZS');
+    </script>
     <style>
         /* Додаткові стилі для цих сторінок */
         body { padding-top: 20px; padding-bottom: 60px; } /* Відступи */


### PR DESCRIPTION
- Add GA tracking to privacy.html, about.html, terms.html (previously missing)
- Unify gtag script loading: use async consistently across all pages
- Update catalogue title hierarchy:
  * Main: "Sticker Catalogue"
  * Country: "{Country} - Sticker Catalogue"
  * Club: "{Club} - {Country} - Sticker Catalogue"
  * Sticker: "Sticker #{ID} - {Club} - {Country} - Sticker Catalogue"