### PR TITLE
Add Sticker Log page - chronological history of all stickers

### DIFF
--- a/stickerlog.html
+++ b/stickerlog.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sticker Log - Chronological History</title>
+    <link rel="icon" href="favicon.ico" type="image/x-icon">
+
+    <!-- SEO Meta Tags -->
+    <meta name="description" content="Browse the chronological history of all stickers added to our catalogue. See when each sticker was hunted and added to the database.">
+    <meta name="keywords" content="football stickers, sticker log, sticker history, panini stickers, chronological list">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://stickerhunt.club/stickerlog.html">
+    <meta property="og:title" content="Sticker Log - Chronological History">
+    <meta property="og:description" content="Browse the chronological history of all stickers added to our catalogue.">
+    <meta property="og:image" content="https://stickerhunt.club/metash.png">
+    <meta property="og:site_name" content="StickerHunt">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://stickerhunt.club/stickerlog.html">
+    <meta property="twitter:title" content="Sticker Log - Chronological History">
+    <meta property="twitter:description" content="Browse the chronological history of all stickers added to our catalogue.">
+    <meta property="twitter:image" content="https://stickerhunt.club/metash.png">
+    <meta property="twitter:site" content="@StickerHunting">
+    <meta property="twitter:creator" content="@StickerHunting">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="style.css">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4Y0MJKGDZS"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-4Y0MJKGDZS');
+    </script>
+</head>
+<body>
+    <header class="app-header">
+        <div class="logo-container">
+           <a href="/index.html"><img src="/logo.png" alt="StickerHunt Logo" id="app-logo"></a>
+        </div>
+        <div id="auth-section">
+             <button id="login-button" class="btn btn-primary google-login" style="display: none;">
+                 <span>Sign in with Google</span>
+             </button>
+             <div id="user-status" style="display: none;">
+                 <strong id="user-nickname" title="Click to edit nickname">Loading...</strong>
+                 <button id="logout-button" class="btn-link">Logout</button>
+                 <form id="edit-nickname-form" style="display: none;">
+                     <input type="text" id="nickname-input" placeholder="Enter new nickname" required minlength="3" maxlength="25" size="15">
+                     <button type="submit" class="btn btn-primary">Save</button>
+                     <button type="button" id="cancel-edit-nickname-button" class="btn btn-secondary">Cancel</button>
+                 </form>
+             </div>
+         </div>
+    </header>
+
+    <main class="container" id="stickerlog-container">
+        <h1>Sticker Log</h1>
+        <p class="page-description">Chronological history of all stickers added to the catalogue</p>
+
+        <div id="loading-indicator" style="text-align: center; padding: 40px;">
+            <p>Loading stickers...</p>
+        </div>
+
+        <div id="stickerlog-content" style="display: none;">
+            <!-- Sticker log entries will be inserted here -->
+        </div>
+
+        <div id="pagination-controls" style="display: none;">
+            <!-- Pagination controls will be inserted here -->
+        </div>
+    </main>
+
+    <footer class="app-footer">
+        <p>
+            <a href="/about.html">About</a> |
+            <a href="/terms.html">Terms of Service</a> |
+            <a href="/privacy.html">Privacy Policy</a>
+        </p>
+        <p>StickerHunt &copy; 2025</p>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script src="shared.js"></script>
+    <script src="stickerlog.js"></script>
+</body>
+</html>

--- a/stickerlog.js
+++ b/stickerlog.js
@@ -1,0 +1,535 @@
+// stickerlog.js - Sticker Log page functionality
+// Displays chronological history of all stickers added to the catalogue
+
+let supabaseClient;
+
+// Auth state
+let currentUser = null;
+let currentUserProfile = null;
+
+// Edit nickname form elements
+let editNicknameForm;
+let nicknameInputElement;
+let cancelEditNicknameButton;
+
+// Pagination state
+const STICKERS_PER_PAGE = 100;
+let currentPage = 1;
+let allStickers = [];
+let groupedStickers = {};
+
+// Initialize Supabase Client
+if (typeof SharedUtils === 'undefined') {
+    console.error('Error: SharedUtils not loaded. Make sure shared.js is included before stickerlog.js');
+    const loadingDiv = document.getElementById('loading-indicator');
+    if (loadingDiv) {
+        loadingDiv.innerHTML = "<p>Initialization error. Sticker log cannot be loaded.</p>";
+    }
+} else {
+    supabaseClient = SharedUtils.initSupabaseClient();
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+    if (supabaseClient) {
+        // Setup auth
+        setupAuth();
+
+        // Initialize nickname editing elements
+        editNicknameForm = document.getElementById('edit-nickname-form');
+        nicknameInputElement = document.getElementById('nickname-input');
+        cancelEditNicknameButton = document.getElementById('cancel-edit-nickname-button');
+        setupNicknameEditing();
+
+        // Check for page parameter in URL
+        const params = new URLSearchParams(window.location.search);
+        const pageParam = params.get('page');
+        if (pageParam) {
+            const pageNum = parseInt(pageParam, 10);
+            if (!isNaN(pageNum) && pageNum > 0) {
+                currentPage = pageNum;
+            }
+        }
+
+        // Load stickers
+        await loadAllStickers();
+    } else {
+        console.error('Supabase client failed to initialize. Sticker log functionality will be limited.');
+        const loadingDiv = document.getElementById('loading-indicator');
+        if (loadingDiv) {
+            loadingDiv.innerHTML = "<p>Initialization error. Sticker log cannot be loaded.</p>";
+        }
+    }
+});
+
+/**
+ * Load all stickers from the database
+ */
+async function loadAllStickers() {
+    const loadingDiv = document.getElementById('loading-indicator');
+    const contentDiv = document.getElementById('stickerlog-content');
+    const paginationDiv = document.getElementById('pagination-controls');
+
+    if (!supabaseClient) {
+        loadingDiv.innerHTML = '<p>Error: Supabase client not initialized. Cannot load data.</p>';
+        return;
+    }
+
+    try {
+        // Fetch all stickers with club information
+        // Order by created_at descending (newest first)
+        const { data: stickers, error: stickersError } = await supabaseClient
+            .from('stickers')
+            .select(`
+                id,
+                created_at,
+                found,
+                location,
+                clubs (
+                    id,
+                    name
+                )
+            `)
+            .order('created_at', { ascending: false });
+
+        if (stickersError) {
+            console.error('Error fetching stickers:', stickersError);
+            loadingDiv.innerHTML = `<p>Could not load stickers: ${stickersError.message}</p>`;
+            return;
+        }
+
+        if (!stickers || stickers.length === 0) {
+            loadingDiv.innerHTML = '<p>No stickers found in the catalogue.</p>';
+            return;
+        }
+
+        allStickers = stickers;
+
+        // Group stickers by date added (created_at date, not hunted date)
+        groupedStickers = groupStickersByDate(stickers);
+
+        // Display stickers for current page
+        displayStickers();
+
+        // Show content and hide loading
+        loadingDiv.style.display = 'none';
+        contentDiv.style.display = 'block';
+        paginationDiv.style.display = 'block';
+
+    } catch (error) {
+        console.error('An error occurred while loading stickers:', error);
+        loadingDiv.innerHTML = `<p>An unexpected error occurred: ${error.message}</p>`;
+    }
+}
+
+/**
+ * Group stickers by their created_at date
+ * @param {Array} stickers - Array of sticker objects
+ * @returns {Object} - Object with dates as keys and arrays of stickers as values
+ */
+function groupStickersByDate(stickers) {
+    const grouped = {};
+
+    stickers.forEach(sticker => {
+        if (!sticker.created_at) return;
+
+        // Extract date without time (YYYY-MM-DD)
+        const dateObj = new Date(sticker.created_at);
+        const dateKey = dateObj.toISOString().split('T')[0];
+
+        if (!grouped[dateKey]) {
+            grouped[dateKey] = [];
+        }
+
+        grouped[dateKey].push(sticker);
+    });
+
+    return grouped;
+}
+
+/**
+ * Display stickers for the current page
+ */
+function displayStickers() {
+    const contentDiv = document.getElementById('stickerlog-content');
+    const paginationDiv = document.getElementById('pagination-controls');
+
+    if (!contentDiv) return;
+
+    // Flatten grouped stickers into a single array while preserving order
+    const flatStickers = [];
+    const sortedDates = Object.keys(groupedStickers).sort((a, b) => b.localeCompare(a)); // Newest first
+
+    sortedDates.forEach(date => {
+        groupedStickers[date].forEach(sticker => {
+            flatStickers.push({ date, sticker });
+        });
+    });
+
+    // Calculate pagination
+    const totalStickers = flatStickers.length;
+    const totalPages = Math.ceil(totalStickers / STICKERS_PER_PAGE);
+    const startIndex = (currentPage - 1) * STICKERS_PER_PAGE;
+    const endIndex = Math.min(startIndex + STICKERS_PER_PAGE, totalStickers);
+    const stickersToDisplay = flatStickers.slice(startIndex, endIndex);
+
+    // Build HTML
+    let html = '';
+    let currentDisplayDate = null;
+
+    stickersToDisplay.forEach(({ date, sticker }) => {
+        // Add date header if this is a new date group
+        if (currentDisplayDate !== date) {
+            currentDisplayDate = date;
+            const dateObj = new Date(date);
+            const formattedDate = dateObj.toLocaleDateString('en-GB', {
+                day: 'numeric',
+                month: 'long',
+                year: 'numeric'
+            });
+
+            html += `<div class="stickerlog-date-header">
+                <h2>${formattedDate}</h2>
+            </div>`;
+        }
+
+        // Format sticker entry
+        const stickerEntry = formatStickerEntry(sticker);
+        html += `<div class="stickerlog-entry">${stickerEntry}</div>`;
+    });
+
+    contentDiv.innerHTML = html;
+
+    // Display pagination controls
+    displayPaginationControls(totalPages, totalStickers, startIndex + 1, endIndex);
+}
+
+/**
+ * Format a single sticker entry
+ * Format: Sticker #1436 from FC Bayern Munich. Hunted 02.08.2024 in Amsterdam, Netherlands
+ * @param {Object} sticker - Sticker object
+ * @returns {string} - Formatted HTML string
+ */
+function formatStickerEntry(sticker) {
+    const stickerId = sticker.id;
+    const clubName = sticker.clubs ? sticker.clubs.name : 'Unknown Club';
+    const clubId = sticker.clubs ? sticker.clubs.id : null;
+
+    let huntedInfo = '';
+    if (sticker.found && sticker.location) {
+        const foundDate = new Date(sticker.found);
+        const formattedFoundDate = foundDate.toLocaleDateString('en-GB', {
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric'
+        });
+        huntedInfo = ` Hunted ${formattedFoundDate} in ${sticker.location}`;
+    } else if (sticker.location) {
+        huntedInfo = ` Hunted in ${sticker.location}`;
+    }
+
+    // Build the entry with links
+    let entry = 'Sticker ';
+    entry += `<a href="catalogue.html?sticker_id=${stickerId}" class="sticker-link">#${stickerId}</a>`;
+    entry += ' from ';
+    if (clubId) {
+        entry += `<a href="catalogue.html?club_id=${clubId}" class="club-link">${clubName}</a>`;
+    } else {
+        entry += clubName;
+    }
+    entry += `.${huntedInfo}`;
+
+    return entry;
+}
+
+/**
+ * Display pagination controls
+ * @param {number} totalPages - Total number of pages
+ * @param {number} totalStickers - Total number of stickers
+ * @param {number} startNum - Starting sticker number on current page
+ * @param {number} endNum - Ending sticker number on current page
+ */
+function displayPaginationControls(totalPages, totalStickers, startNum, endNum) {
+    const paginationDiv = document.getElementById('pagination-controls');
+    if (!paginationDiv) return;
+
+    let html = '<div class="pagination-wrapper">';
+
+    // Info text
+    html += `<div class="pagination-info">Showing ${startNum}-${endNum} of ${totalStickers} stickers</div>`;
+
+    // Pagination buttons
+    html += '<div class="pagination-buttons">';
+
+    // Previous button
+    if (currentPage > 1) {
+        html += `<a href="?page=${currentPage - 1}" class="pagination-btn">← Previous</a>`;
+    } else {
+        html += `<span class="pagination-btn pagination-btn-disabled">← Previous</span>`;
+    }
+
+    // Page numbers
+    const maxPagesToShow = 7;
+    let startPage = Math.max(1, currentPage - Math.floor(maxPagesToShow / 2));
+    let endPage = Math.min(totalPages, startPage + maxPagesToShow - 1);
+
+    // Adjust if we're near the end
+    if (endPage - startPage < maxPagesToShow - 1) {
+        startPage = Math.max(1, endPage - maxPagesToShow + 1);
+    }
+
+    // First page
+    if (startPage > 1) {
+        html += `<a href="?page=1" class="pagination-btn">1</a>`;
+        if (startPage > 2) {
+            html += `<span class="pagination-ellipsis">...</span>`;
+        }
+    }
+
+    // Page numbers
+    for (let i = startPage; i <= endPage; i++) {
+        if (i === currentPage) {
+            html += `<span class="pagination-btn pagination-btn-active">${i}</span>`;
+        } else {
+            html += `<a href="?page=${i}" class="pagination-btn">${i}</a>`;
+        }
+    }
+
+    // Last page
+    if (endPage < totalPages) {
+        if (endPage < totalPages - 1) {
+            html += `<span class="pagination-ellipsis">...</span>`;
+        }
+        html += `<a href="?page=${totalPages}" class="pagination-btn">${totalPages}</a>`;
+    }
+
+    // Next button
+    if (currentPage < totalPages) {
+        html += `<a href="?page=${currentPage + 1}" class="pagination-btn">Next →</a>`;
+    } else {
+        html += `<span class="pagination-btn pagination-btn-disabled">Next →</span>`;
+    }
+
+    html += '</div>'; // Close pagination-buttons
+    html += '</div>'; // Close pagination-wrapper
+
+    paginationDiv.innerHTML = html;
+}
+
+// ========== AUTH FUNCTIONS ==========
+
+// Load user profile
+async function loadAndSetUserProfile(user) {
+    if (!supabaseClient || !user) return;
+
+    const profile = await SharedUtils.loadUserProfile(supabaseClient, user);
+    if (profile) {
+        currentUserProfile = profile;
+        SharedUtils.cacheUserProfile(profile);
+    }
+}
+
+// Update auth UI
+function updateAuthUI(user) {
+    const loginButton = document.getElementById('login-button');
+    const userStatusElement = document.getElementById('user-status');
+    const userNicknameElement = document.getElementById('user-nickname');
+
+    if (!loginButton || !userStatusElement || !userNicknameElement) return;
+
+    if (user) {
+        const displayName = currentUserProfile?.username || 'Loading...';
+        userNicknameElement.textContent = SharedUtils.truncateString(displayName);
+        loginButton.style.display = 'none';
+        userStatusElement.style.display = 'flex';
+    } else {
+        loginButton.style.display = 'none';
+        userStatusElement.style.display = 'none';
+    }
+}
+
+// Login with Google
+function handleLoginClick() {
+    if (!supabaseClient) return;
+    SharedUtils.loginWithGoogle(supabaseClient, '/stickerlog.html').then(result => {
+        if (result.error) {
+            alert('Login failed. Please try again.');
+        }
+    });
+}
+
+// Logout
+async function handleLogoutClick() {
+    if (!supabaseClient) return;
+
+    const result = await SharedUtils.logout(supabaseClient, currentUser?.id);
+    if (result.error) {
+        alert('Logout failed. Please try again.');
+    } else {
+        window.location.reload();
+    }
+}
+
+/**
+ * Setup auth
+ */
+function setupAuth() {
+    if (!supabaseClient) return;
+
+    const loginButton = document.getElementById('login-button');
+    const logoutButton = document.getElementById('logout-button');
+
+    // Set up button handlers
+    if (loginButton) {
+        loginButton.addEventListener('click', handleLoginClick);
+    }
+    if (logoutButton) {
+        logoutButton.addEventListener('click', handleLogoutClick);
+    }
+
+    // Get current session
+    supabaseClient.auth.getSession().then(async ({ data: { session }, error }) => {
+        if (error) {
+            console.error('Error getting session:', error);
+            updateAuthUI(null);
+            setupAuthStateListener();
+            return;
+        }
+
+        const user = session?.user ?? null;
+
+        if (user) {
+            currentUser = user;
+
+            // Load cached profile first for fast UI
+            const cachedProfile = SharedUtils.loadCachedProfile(user.id);
+            if (cachedProfile) {
+                currentUserProfile = cachedProfile;
+                updateAuthUI(user);
+            }
+
+            // Load fresh profile and update UI
+            await loadAndSetUserProfile(user);
+            updateAuthUI(user);
+        } else {
+            updateAuthUI(null);
+        }
+
+        // Set up listener for future auth changes only
+        setupAuthStateListener();
+    });
+}
+
+/**
+ * Auth state listener
+ */
+function setupAuthStateListener() {
+    if (!supabaseClient) return;
+
+    supabaseClient.auth.onAuthStateChange(async (event, session) => {
+        // Skip INITIAL_SESSION
+        if (event === 'INITIAL_SESSION') {
+            return;
+        }
+
+        const user = session?.user ?? null;
+
+        // Handle logout
+        if (event === 'SIGNED_OUT') {
+            if (currentUser) {
+                SharedUtils.clearCachedProfile(currentUser.id);
+            }
+            currentUser = null;
+            currentUserProfile = null;
+            updateAuthUI(null);
+            return;
+        }
+
+        // Handle new sign in
+        if (event === 'SIGNED_IN' && user) {
+            if (!currentUser || currentUser.id !== user.id) {
+                currentUser = user;
+                const cachedProfile = SharedUtils.loadCachedProfile(user.id);
+                if (cachedProfile) {
+                    currentUserProfile = cachedProfile;
+                }
+                updateAuthUI(user);
+                await loadAndSetUserProfile(user);
+                updateAuthUI(user);
+            }
+        }
+
+        // Handle token refresh
+        if (event === 'TOKEN_REFRESHED' && user) {
+            currentUser = user;
+        }
+    });
+}
+
+// ========== NICKNAME EDITING FUNCTIONS ==========
+
+function setupNicknameEditing() {
+    const userNicknameElement = document.getElementById('user-nickname');
+    if (!userNicknameElement) return;
+
+    userNicknameElement.addEventListener('click', showNicknameEditForm);
+
+    if (editNicknameForm) {
+        editNicknameForm.addEventListener('submit', handleNicknameSave);
+    }
+    if (cancelEditNicknameButton) {
+        cancelEditNicknameButton.addEventListener('click', hideNicknameEditForm);
+    }
+}
+
+function showNicknameEditForm() {
+    if (!currentUserProfile) {
+        alert('Please wait for your profile to load...');
+        return;
+    }
+
+    if (!editNicknameForm || !nicknameInputElement) return;
+
+    nicknameInputElement.value = currentUserProfile.username || '';
+    editNicknameForm.style.display = 'block';
+    nicknameInputElement.focus();
+    nicknameInputElement.select();
+}
+
+function hideNicknameEditForm() {
+    if (!editNicknameForm || !nicknameInputElement) return;
+    editNicknameForm.style.display = 'none';
+    nicknameInputElement.value = '';
+}
+
+async function handleNicknameSave(event) {
+    event.preventDefault();
+
+    if (!currentUser || !nicknameInputElement || !supabaseClient || !currentUserProfile) {
+        alert('Cannot save nickname');
+        return;
+    }
+
+    const newNickname = nicknameInputElement.value.trim();
+
+    if (newNickname === currentUserProfile.username) {
+        hideNicknameEditForm();
+        return;
+    }
+
+    const result = await SharedUtils.updateNickname(supabaseClient, currentUser.id, newNickname);
+
+    if (result.error) {
+        alert(`Update failed: ${result.error.message}`);
+    } else {
+        currentUserProfile.username = result.data.username;
+        SharedUtils.cacheUserProfile(currentUserProfile);
+
+        const userNicknameElement = document.getElementById('user-nickname');
+        if (userNicknameElement) {
+            userNicknameElement.textContent = SharedUtils.truncateString(result.data.username);
+        }
+
+        hideNicknameEditForm();
+        alert('Nickname updated successfully!');
+    }
+}

--- a/style.css
+++ b/style.css
@@ -1461,3 +1461,159 @@ body.home-page #app-logo {
         text-align: right;
     }
 }
+
+/* ------------------------------ */
+/* Sticker Log Page               */
+/* ------------------------------ */
+
+/* Page description */
+.page-description {
+    color: var(--color-info-text);
+    font-size: 0.95em;
+    margin-bottom: calc(var(--spacing-unit) * 3);
+}
+
+/* Sticker log content */
+#stickerlog-content {
+    text-align: left;
+    margin-top: calc(var(--spacing-unit) * 3);
+}
+
+/* Date headers */
+.stickerlog-date-header {
+    margin-top: calc(var(--spacing-unit) * 4);
+    margin-bottom: calc(var(--spacing-unit) * 2);
+    padding-bottom: calc(var(--spacing-unit) * 1);
+    border-bottom: 2px solid var(--color-accent);
+}
+
+.stickerlog-date-header h2 {
+    font-size: 1.3em;
+    font-weight: 600;
+    color: var(--color-text);
+    margin: 0;
+}
+
+.stickerlog-date-header:first-child {
+    margin-top: 0;
+}
+
+/* Sticker entries */
+.stickerlog-entry {
+    padding: calc(var(--spacing-unit) * 1) 0;
+    border-bottom: 1px solid var(--color-border);
+    color: var(--color-text);
+    font-size: 1em;
+    line-height: 1.6;
+}
+
+.stickerlog-entry:last-child {
+    border-bottom: none;
+}
+
+/* Sticker and club links */
+.stickerlog-entry .sticker-link {
+    color: var(--color-link);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.stickerlog-entry .club-link {
+    color: var(--color-link);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+@media (hover: hover) {
+    .stickerlog-entry .sticker-link:hover,
+    .stickerlog-entry .club-link:hover {
+        color: var(--color-link-hover);
+        text-decoration: underline;
+    }
+}
+
+/* Pagination */
+#pagination-controls {
+    margin-top: calc(var(--spacing-unit) * 4);
+    margin-bottom: calc(var(--spacing-unit) * 3);
+}
+
+.pagination-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--spacing-unit) * 2);
+    align-items: center;
+}
+
+.pagination-info {
+    font-size: 0.9em;
+    color: var(--color-info-text);
+    text-align: center;
+}
+
+.pagination-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: calc(var(--spacing-unit) * 1);
+    justify-content: center;
+    align-items: center;
+}
+
+.pagination-btn {
+    display: inline-block;
+    padding: calc(var(--spacing-unit) * 0.75) calc(var(--spacing-unit) * 1.5);
+    min-width: 44px;
+    text-align: center;
+    background-color: var(--color-background);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+    text-decoration: none;
+    font-size: 0.95em;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.pagination-btn-active {
+    background-color: var(--color-accent);
+    color: var(--color-accent-text);
+    border-color: var(--color-accent);
+    font-weight: 600;
+}
+
+.pagination-btn-disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+    background-color: var(--color-disabled-bg);
+    color: var(--color-disabled-text);
+    border-color: var(--color-border);
+}
+
+@media (hover: hover) {
+    .pagination-btn:not(.pagination-btn-active):not(.pagination-btn-disabled):hover {
+        background-color: var(--color-secondary-bg-hover);
+        border-color: var(--color-accent);
+    }
+}
+
+.pagination-ellipsis {
+    padding: 0 calc(var(--spacing-unit) * 0.5);
+    color: var(--color-info-text);
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+    .stickerlog-date-header h2 {
+        font-size: 1.1em;
+    }
+
+    .stickerlog-entry {
+        font-size: 0.9em;
+        padding: calc(var(--spacing-unit) * 0.75) 0;
+    }
+
+    .pagination-btn {
+        padding: calc(var(--spacing-unit) * 0.6) calc(var(--spacing-unit) * 1.2);
+        min-width: 40px;
+        font-size: 0.85em;
+    }
+}


### PR DESCRIPTION
Created a new page stickerlog.html that displays all stickers in chronological order by their catalog addition date (created_at). Features include:

- Display format: "Sticker #ID from ClubName. Hunted DATE in LOCATION"
- Grouped by date added to catalog (not hunted date)
- Sticker numbers link to sticker detail pages
- Club names link to club pages
- Pagination showing 100 stickers per page
- Newest stickers shown first
- Responsive design matching existing site style

Files added:
- stickerlog.html: Main page structure with SEO meta tags
- stickerlog.js: JavaScript logic for data loading, pagination, and display
- style.css: Added styling for sticker log layout and pagination controls