### PR TITLE
Refine sticker log styling to match catalogue design

### DIFF
--- a/catalogue.js
+++ b/catalogue.js
@@ -339,14 +339,8 @@ async function loadLastStickers() {
             groupedByDate[date].forEach(sticker => {
                 const clubName = sticker.clubs?.name || 'Unknown Club';
                 const clubId = sticker.clubs?.id || null;
-                const countryCode = sticker.clubs?.country || '';
-                const flagEmoji = countryCodeToFlagEmoji[countryCode.toUpperCase()] || '';
 
                 let entry = '<a href="catalogue.html?sticker_id=' + sticker.id + '" class="sticker-link">#' + sticker.id + '</a>, ';
-
-                if (flagEmoji) {
-                    entry += flagEmoji + ' ';
-                }
 
                 if (clubId) {
                     entry += '<a href="catalogue.html?club_id=' + clubId + '" class="club-link">' + clubName + '</a>';

--- a/stickerlog.js
+++ b/stickerlog.js
@@ -217,7 +217,7 @@ function displayStickers() {
 
 /**
  * Format a single sticker entry
- * Format: #2866, 🇦🇹 FK Austria Viena.
+ * Format: #2866, FK Austria Viena.
  * @param {Object} sticker - Sticker object
  * @returns {string} - Formatted HTML string
  */
@@ -225,44 +225,10 @@ function formatStickerEntry(sticker) {
     const stickerId = sticker.id;
     const clubName = sticker.clubs ? sticker.clubs.name : 'Unknown Club';
     const clubId = sticker.clubs ? sticker.clubs.id : null;
-    const countryCode = sticker.clubs?.country || '';
-
-    // Get country flag emoji
-    const countryCodeToFlagEmoji = {
-        "AFG": "🇦🇫", "ALB": "🇦🇱", "DZA": "🇩🇿", "AND": "🇦🇩", "AGO": "🇦🇴", "ARG": "🇦🇷", "ARM": "🇦🇲",
-        "AUS": "🇦🇺", "AUT": "🇦🇹", "AZE": "🇦🇿", "BHS": "🇧🇸", "BHR": "🇧🇭", "BGD": "🇧🇩", "BLR": "🇧🇾",
-        "BEL": "🇧🇪", "BLZ": "🇧🇿", "BEN": "🇧🇯", "BOL": "🇧🇴", "BIH": "🇧🇦", "BWA": "🇧🇼", "BRA": "🇧🇷",
-        "BGR": "🇧🇬", "BFA": "🇧🇫", "KHM": "🇰🇭", "CMR": "🇨🇲", "CAN": "🇨🇦", "CPV": "🇨🇻", "CAF": "🇨🇫",
-        "TCD": "🇹🇩", "CHL": "🇨🇱", "CHN": "🇨🇳", "COL": "🇨🇴", "COG": "🇨🇬", "CRI": "🇨🇷", "HRV": "🇭🇷",
-        "CUB": "🇨🇺", "CYP": "🇨🇾", "CZE": "🇨🇿", "DNK": "🇩🇰", "DJI": "🇩🇯", "DOM": "🇩🇴", "ECU": "🇪🇨",
-        "EGY": "🇪🇬", "SLV": "🇸🇻", "GNQ": "🇬🇶", "EST": "🇪🇪", "ETH": "🇪🇹", "FJI": "🇫🇯", "FIN": "🇫🇮",
-        "FRA": "🇫🇷", "GAB": "🇬🇦", "GMB": "🇬🇲", "GEO": "🇬🇪", "DEU": "🇩🇪", "GHA": "🇬🇭", "GRC": "🇬🇷",
-        "GTM": "🇬🇹", "GIN": "🇬🇳", "HTI": "🇭🇹", "HND": "🇭🇳", "HUN": "🇭🇺", "ISL": "🇮🇸", "IND": "🇮🇳",
-        "IDN": "🇮🇩", "IRN": "🇮🇷", "IRQ": "🇮🇶", "IRL": "🇮🇪", "ISR": "🇮🇱", "ITA": "🇮🇹", "CIV": "🇨🇮",
-        "JAM": "🇯🇲", "JPN": "🇯🇵", "JOR": "🇯🇴", "KAZ": "🇰🇿", "KEN": "🇰🇪", "KWT": "🇰🇼", "KGZ": "🇰🇬",
-        "LVA": "🇱🇻", "LBN": "🇱🇧", "LBR": "🇱🇷", "LBY": "🇱🇾", "LIE": "🇱🇮", "LTU": "🇱🇹", "LUX": "🇱🇺",
-        "MKD": "🇲🇰", "MDG": "🇲🇬", "MWI": "🇲🇼", "MYS": "🇲🇾", "MLI": "🇲🇱", "MLT": "🇲🇹", "MRT": "🇲🇷",
-        "MEX": "🇲🇽", "MDA": "🇲🇩", "MCO": "🇲🇨", "MNG": "🇲🇳", "MNE": "🇲🇪", "MAR": "🇲🇦", "MOZ": "🇲🇿",
-        "NPL": "🇳🇵", "NLD": "🇳🇱", "NZL": "🇳🇿", "NIC": "🇳🇮", "NER": "🇳🇪", "NGA": "🇳🇬", "PRK": "🇰🇵",
-        "NOR": "🇳🇴", "OMN": "🇴🇲", "PAK": "🇵🇰", "PAN": "🇵🇦", "PNG": "🇵🇬", "PRY": "🇵🇾", "PER": "🇵🇪",
-        "PHL": "🇵🇭", "POL": "🇵🇱", "PRT": "🇵🇹", "QAT": "🇶🇦", "ROU": "🇷🇴", "RUS": "🇷🇺", "RWA": "🇷🇼",
-        "SAU": "🇸🇦", "SEN": "🇸🇳", "SRB": "🇷🇸", "SLE": "🇸🇱", "SGP": "🇸🇬", "SVK": "🇸🇰", "SVN": "🇸🇮",
-        "SOM": "🇸🇴", "ZAF": "🇿🇦", "KOR": "🇰🇷", "ESP": "🇪🇸", "LKA": "🇱🇰", "SDN": "🇸🇩", "SWE": "🇸🇪",
-        "CHE": "🇨🇭", "SYR": "🇸🇾", "TWN": "🇹🇼", "TZA": "🇹🇿", "THA": "🇹🇭", "TGO": "🇹🇬", "TUN": "🇹🇳",
-        "TUR": "🇹🇷", "UGA": "🇺🇬", "UKR": "🇺🇦", "ARE": "🇦🇪", "GBR": "🇬🇧", "USA": "🇺🇸", "URY": "🇺🇾",
-        "UZB": "🇺🇿", "VEN": "🇻🇪", "VNM": "🇻🇳", "YEM": "🇾🇪", "ZMB": "🇿🇲", "ZWE": "🇿🇼",
-        "ENG": "🏴󠁧󠁢󠁥󠁮󠁧󠁿", "SCO": "🏴󠁧󠁢󠁳󠁣󠁴󠁿", "WLS": "🏴󠁧󠁢󠁷󠁬󠁳󠁿", "NIR": "🇬🇧"
-    };
-
-    const flagEmoji = countryCodeToFlagEmoji[countryCode.toUpperCase()] || '';
 
     // Build the entry with links
-    // Format: #2866, 🇦🇹 FK Austria Viena.
+    // Format: #2866, FK Austria Viena.
     let entry = '<a href="catalogue.html?sticker_id=' + stickerId + '" class="sticker-link">#' + stickerId + '</a>, ';
-
-    if (flagEmoji) {
-        entry += flagEmoji + ' ';
-    }
 
     if (clubId) {
         entry += '<a href="catalogue.html?club_id=' + clubId + '" class="club-link">' + clubName + '</a>';

--- a/style.css
+++ b/style.css
@@ -1095,16 +1095,19 @@ body.home-page #app-logo {
 }
 
 .last-stickers-section h3 {
-    font-size: 1.3em;
+    font-size: 1.4em;
     font-weight: 600;
-    margin-bottom: calc(var(--spacing-unit) * 2);
+    margin-bottom: calc(var(--spacing-unit) * 1.5);
+    padding-bottom: calc(var(--spacing-unit) * 0.5);
+    border-bottom: 1px dashed var(--color-border);
 }
 
 .last-stickers-date-header {
     margin-top: calc(var(--spacing-unit) * 2);
-    margin-bottom: calc(var(--spacing-unit) * 0.5);
+    margin-bottom: calc(var(--spacing-unit) * 1);
     color: var(--color-text);
-    font-size: 0.95em;
+    font-size: 1em;
+    font-weight: 600;
 }
 
 .last-stickers-date-header:first-of-type {
@@ -1113,20 +1116,17 @@ body.home-page #app-logo {
 
 .last-stickers-list {
     list-style: none;
-    padding: 0;
-    margin: 0 0 calc(var(--spacing-unit) * 1) 0;
+    padding-left: 0;
 }
 
 .last-stickers-list li {
-    padding: calc(var(--spacing-unit) * 0.5) 0;
-    color: var(--color-text);
-    font-size: 0.95em;
-    line-height: 1.6;
+    margin-bottom: var(--spacing-unit);
+    font-size: 1.1em;
 }
 
 .last-stickers-list .sticker-link,
 .last-stickers-list .club-link {
-    color: var(--color-link);
+    color: var(--color-info-text);
     text-decoration: none;
     font-weight: 500;
 }
@@ -1134,7 +1134,7 @@ body.home-page #app-logo {
 @media (hover: hover) {
     .last-stickers-list .sticker-link:hover,
     .last-stickers-list .club-link:hover {
-        color: var(--color-link-hover);
+        color: var(--color-link);
         text-decoration: underline;
     }
 }
@@ -1142,7 +1142,7 @@ body.home-page #app-logo {
 .view-full-log-link {
     display: inline-block;
     margin-top: calc(var(--spacing-unit) * 1.5);
-    color: var(--color-link);
+    color: var(--color-info-text);
     text-decoration: none;
     font-weight: 500;
     font-size: 0.95em;
@@ -1150,7 +1150,7 @@ body.home-page #app-logo {
 
 @media (hover: hover) {
     .view-full-log-link:hover {
-        color: var(--color-link-hover);
+        color: var(--color-link);
         text-decoration: underline;
     }
 }
@@ -1547,49 +1547,40 @@ body.home-page #app-logo {
     margin-top: calc(var(--spacing-unit) * 3);
 }
 
-/* Date headers */
+/* Date headers - styled like continent sections */
 .stickerlog-date-header {
-    margin-top: calc(var(--spacing-unit) * 4);
-    margin-bottom: calc(var(--spacing-unit) * 2);
-    padding-bottom: calc(var(--spacing-unit) * 1);
-    border-bottom: 2px solid var(--color-accent);
+    margin-top: calc(var(--spacing-unit) * 3);
+    margin-bottom: calc(var(--spacing-unit) * 1.5);
 }
 
 .stickerlog-date-header h2 {
-    font-size: 1.3em;
+    font-size: 1.4em;
     font-weight: 600;
     color: var(--color-text);
-    margin: 0;
+    margin: 0 0 calc(var(--spacing-unit) * 1.5) 0;
+    padding-bottom: calc(var(--spacing-unit) * 0.5);
+    border-bottom: 1px dashed var(--color-border);
 }
 
 .stickerlog-date-header:first-child {
     margin-top: 0;
 }
 
-/* Sticker entries list */
+/* Sticker entries list - styled like country list */
 .stickerlog-entries-list {
     list-style: none;
-    padding: 0;
-    margin: 0;
+    padding-left: 0;
 }
 
 .stickerlog-entry {
-    padding: calc(var(--spacing-unit) * 0.5) 0;
-    color: var(--color-text);
-    font-size: 0.95em;
-    line-height: 1.6;
-    text-align: left;
+    margin-bottom: var(--spacing-unit);
+    font-size: 1.1em;
 }
 
-/* Sticker and club links */
-.stickerlog-entry .sticker-link {
-    color: var(--color-link);
-    text-decoration: none;
-    font-weight: 500;
-}
-
+/* Sticker and club links - styled like country links */
+.stickerlog-entry .sticker-link,
 .stickerlog-entry .club-link {
-    color: var(--color-link);
+    color: var(--color-info-text);
     text-decoration: none;
     font-weight: 500;
 }
@@ -1597,7 +1588,7 @@ body.home-page #app-logo {
 @media (hover: hover) {
     .stickerlog-entry .sticker-link:hover,
     .stickerlog-entry .club-link:hover {
-        color: var(--color-link-hover);
+        color: var(--color-link);
         text-decoration: underline;
     }
 }
@@ -1673,20 +1664,24 @@ body.home-page #app-logo {
 /* Responsive adjustments */
 @media (max-width: 600px) {
     .stickerlog-date-header h2 {
-        font-size: 1.1em;
-        text-align: left;
+        font-size: 1.2em;
     }
 
     .stickerlog-entry {
-        font-size: 0.85em;
-        padding: calc(var(--spacing-unit) * 1.2);
-        margin-bottom: calc(var(--spacing-unit) * 1.2);
-        line-height: 1.6;
+        font-size: 1em;
     }
 
     .pagination-btn {
         padding: calc(var(--spacing-unit) * 0.6) calc(var(--spacing-unit) * 1.2);
         min-width: 40px;
         font-size: 0.85em;
+    }
+
+    .last-stickers-section h3 {
+        font-size: 1.2em;
+    }
+
+    .last-stickers-list li {
+        font-size: 1em;
     }
 }


### PR DESCRIPTION
Updated sticker log and last stickers section to match catalogue style:

Format changes:
- Removed country flag emoji before club name (user adds flags manually)
- Format now: "#ID, ClubName." instead of "#ID, 🇦🇹 ClubName."

Styling updates:
- Date headers now match continent section style (1px dashed border)
- Sticker/club links styled like country links (black text, blue on hover)
- "View full stickerLog" link follows same style pattern
- Spacing between entries matches country list (var(--spacing-unit))
- Font sizes: 1.4em for headers, 1.1em for entries (1.2em/1em on mobile)

CSS improvements:
- Unified color scheme: var(--color-info-text) default, var(--color-link) on hover
- Consistent margins and padding throughout
- Border style: 1px dashed var(--color-border) for section headers
- Mobile responsive styling updated to match

This creates a consistent visual language across catalogue and sticker log pages.