### PR TITLE
Redesign quiz desktop layout with horizontal sticker display

### DIFF
--- a/quiz.html
+++ b/quiz.html
@@ -97,11 +97,13 @@
              <div id="sticker-container">
                  <img id="sticker-image" src="" alt="Club Sticker">
              </div>
-             <div id="options" class="button-group options-group">
+             <div class="game-right-panel">
+                 <div class="game-info">
+                     <div id="timer">Time: <span id="time-left">10</span></div>
+                     <div id="score">Score: <span id="current-score">0</span></div>
                  </div>
-             <div class="game-info">
-                 <div id="timer">Time: <span id="time-left">10</span></div>
-                 <div id="score">Score: <span id="current-score">0</span></div>
+                 <div id="options" class="button-group options-group">
+                 </div>
              </div>
          </div>
 

--- a/style.css
+++ b/style.css
@@ -120,6 +120,58 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
 #sticker-image { width: 100%; height: 100%; object-fit: contain; }
 #sticker-image[alt*="Loading"], #sticker-image[alt*="Error"] { width: 50px; height: 50px; }
 #sticker-image.fade-in { animation: fadeIn 0.4s ease-out; }
+
+/* Desktop horizontal layout for quiz */
+@media (min-width: 1000px) {
+    #game-area {
+        display: flex;
+        align-items: flex-start;
+        justify-content: center;
+        gap: calc(var(--spacing-unit) * 4);
+        margin-top: calc(var(--spacing-unit) * 2);
+        /* Allow game area to expand beyond container */
+        width: calc(100vw - var(--spacing-unit) * 4);
+        max-width: 1000px;
+        margin-left: auto;
+        margin-right: auto;
+        position: relative;
+        left: 50%;
+        transform: translateX(-50%);
+    }
+
+    #sticker-container {
+        width: 600px;
+        height: 600px;
+        margin: 0;
+        flex-shrink: 0;
+    }
+
+    .game-right-panel {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: calc(var(--spacing-unit) * 2);
+    }
+
+    #game-area .game-info {
+        order: -1;
+        margin-top: 0;
+        margin-bottom: calc(var(--spacing-unit) * 1);
+        max-width: none;
+        gap: calc(var(--spacing-unit) * 4);
+    }
+
+    #game-area .options-group {
+        grid-template-columns: 1fr;
+        gap: calc(var(--spacing-unit) * 1.5);
+    }
+}
+
+/* Default styles for game-right-panel (mobile/tablet) */
+.game-right-panel {
+    display: contents; /* On mobile, behave as if wrapper doesn't exist */
+}
+
 .options-group {
     display: grid;
     grid-template-columns: repeat(2, 300px); /* Fixed width matching sticker */


### PR DESCRIPTION
- Add horizontal layout for quiz game on screens 1000px+ wide
- Display sticker on the left at 600x600px (doubled from 300px)
- Move timer and score to the right side above answer options
- Stack answer options vertically in single column on desktop
- Wrap options and game info in .game-right-panel container
- Use display:contents for mobile to preserve existing vertical layout
- Ensure game area can expand beyond container constraints