### PR TITLE
Redesign quiz end screen layout for desktop and mobile

### DIFF
--- a/quiz.html
+++ b/quiz.html
@@ -108,22 +108,23 @@
          </div>
 
         <div id="result-area" style="display: none;">
-             <h2>Game Over!</h2>
-             <p class="final-score-container">Your final score: <span id="final-score">0</span></p>
-             <p class="rank-container personal-rank" id="personal-rank-container" style="display: none;"></p>
-             <button id="play-again" class="btn btn-primary btn-large">Play Again</button>
-             <p class="rank-container timeframe-ranks" id="timeframe-ranks-container" style="display: none;"></p>
-             <button id="result-leaderboard-button" class="btn btn-secondary btn-large" onclick="window.location.href='/leaderboard.html'">View leaderboard</button>
-             <button id="result-sign-in-button" class="btn btn-secondary btn-large" style="display: none;">Sign In (hard levels, leaderboard)</button>
-
-             <div id="failed-sticker-section" style="display: none;">
-                 <div id="failed-sticker-container">
-                     <img id="failed-sticker-image" src="" alt="Failed Sticker">
-                 </div>
-                 <p id="failed-sticker-name"></p>
+             <div id="failed-sticker-container">
+                 <img id="failed-sticker-image" src="" alt="Failed Sticker">
              </div>
-
-             <a href="/catalogue.html" id="result-catalogue-button" class="btn btn-secondary btn-large">View more in catalogue</a>
+             <div class="result-right-panel">
+                 <div class="result-info">
+                     <h2 id="game-over-text">Game Over!</h2>
+                     <p class="final-score-container">Your final score: <span id="final-score">0</span></p>
+                 </div>
+                 <div class="result-buttons">
+                     <button id="result-leaderboard-button" class="btn btn-secondary btn-large">Better than <span id="percentile-value">0</span>% players</button>
+                     <button id="play-again" class="btn btn-primary btn-large">Play Again</button>
+                     <a href="/catalogue.html" id="result-sticker-info-button" class="btn btn-secondary btn-large">View sticker info</a>
+                     <button id="result-sign-in-button" class="btn btn-secondary btn-large" style="display: none;">Sign In (hard levels, leaderboard)</button>
+                 </div>
+             </div>
+             <p class="rank-container personal-rank" id="personal-rank-container" style="display: none;"></p>
+             <p class="rank-container timeframe-ranks" id="timeframe-ranks-container" style="display: none;"></p>
          </div>
 
         <section id="leaderboard-section" style="display: none;">

--- a/style.css
+++ b/style.css
@@ -267,23 +267,163 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
 
 
 /* --- Result Area --- */
-#result-area { margin-top: calc(var(--spacing-unit) * 4); padding: calc(var(--spacing-unit) * 3) calc(var(--spacing-unit) * 2); }
-#result-area h2 { font-size: 2.5em; font-weight: 700; color: var(--color-text); margin-bottom: var(--spacing-unit); }
-#result-area .final-score-container { font-size: 1.8em; font-weight: 500; color: var(--color-info-text); margin-bottom: calc(var(--spacing-unit) * 1); }
-#result-area #final-score { font-size: 1em; font-weight: 700; color: var(--color-accent-darker); display: inline-block; margin-left: calc(var(--spacing-unit) * 0.5); }
-#result-area .rank-container { font-size: 1.8em; font-weight: 500; color: var(--color-info-text); margin-bottom: calc(var(--spacing-unit) * 2); margin-top: 0; }
-#result-area .rank-container.timeframe-ranks { font-size: 0.95em; font-weight: 400; color: var(--color-disabled-text); margin-bottom: calc(var(--spacing-unit) * 2); margin-top: calc(var(--spacing-unit) * 2); white-space: nowrap; letter-spacing: 0.02em; }
-#result-area .save-message { font-size: 0.9em; font-style: italic; color: var(--color-success); margin-top: calc(var(--spacing-unit) * -2); margin-bottom: calc(var(--spacing-unit) * 3); }
-#result-area button { display: block; width: 100%; max-width: 400px; margin-left: auto; margin-right: auto; }
-#result-area #play-again { margin-top: calc(var(--spacing-unit) * 2); }
-#result-area #result-sign-in-button { margin-top: calc(var(--spacing-unit) * 1.5); }
+#result-area {
+    margin-top: calc(var(--spacing-unit) * 2);
+    padding: calc(var(--spacing-unit) * 2);
+    text-align: center;
+}
 
-/* --- Failed Sticker Section --- */
-#failed-sticker-section { margin-top: calc(var(--spacing-unit) * 3); display: flex; flex-direction: column; align-items: center; }
-#failed-sticker-container { width: 80%; max-width: 400px; aspect-ratio: 1 / 1; margin-bottom: calc(var(--spacing-unit) * 1.5); background-color: var(--color-secondary-bg); border: 1px solid var(--color-border); border-radius: var(--border-radius); overflow: hidden; display: flex; align-items: center; justify-content: center; }
-#failed-sticker-image { width: 100%; height: 100%; object-fit: contain; }
-#failed-sticker-name { font-size: 1.2em; font-weight: 600; color: var(--color-text); margin: 0; text-align: center; }
-#result-area #result-catalogue-button { margin-top: calc(var(--spacing-unit) * 2); text-decoration: none; display: flex; align-items: center; justify-content: center; width: 100%; max-width: 400px; margin-left: auto; margin-right: auto; box-sizing: border-box; }
+/* Failed sticker container in result area */
+#result-area #failed-sticker-container {
+    width: 300px;
+    height: 300px;
+    margin: 0 auto calc(var(--spacing-unit) * 3) auto;
+    background-color: var(--color-secondary-bg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+#result-area #failed-sticker-image {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+/* Result right panel (mobile: flows naturally) */
+.result-right-panel {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: calc(var(--spacing-unit) * 2);
+}
+
+/* Result info section */
+.result-info {
+    text-align: center;
+}
+
+/* Game Over text with red color and animation */
+#result-area #game-over-text {
+    font-size: 2em;
+    font-weight: 700;
+    color: var(--color-error);
+    margin-bottom: calc(var(--spacing-unit) * 0.5);
+}
+
+#game-over-text.game-over-animated {
+    animation: game-over-flash 0.8s ease-out;
+}
+
+@keyframes game-over-flash {
+    0% { transform: scale(1); opacity: 1; }
+    25% { transform: scale(1.4); opacity: 0.8; }
+    50% { transform: scale(1.5); opacity: 0.7; }
+    75% { transform: scale(1.2); opacity: 0.9; }
+    100% { transform: scale(1); opacity: 1; }
+}
+
+#result-area .final-score-container {
+    font-size: 1.3em;
+    font-weight: 500;
+    color: var(--color-info-text);
+    margin: 0;
+}
+#result-area #final-score {
+    font-weight: 700;
+    color: var(--color-accent-darker);
+}
+
+/* Result buttons */
+.result-buttons {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: calc(var(--spacing-unit) * 1.5);
+    width: 100%;
+    max-width: 300px;
+}
+
+.result-buttons .btn {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    box-sizing: border-box;
+}
+
+#result-area .rank-container {
+    display: none; /* Hidden in new design */
+}
+
+/* Desktop horizontal layout for result area */
+@media (min-width: 1000px) {
+    #result-area[style*="block"] {
+        display: flex !important;
+        flex-direction: row;
+        align-items: flex-start;
+        justify-content: center;
+        gap: calc(var(--spacing-unit) * 4);
+        margin-top: calc(var(--spacing-unit) * 2);
+        width: calc(100vw - var(--spacing-unit) * 4);
+        max-width: 1000px;
+        margin-left: auto;
+        margin-right: auto;
+        position: relative;
+        left: 50%;
+        transform: translateX(-50%);
+    }
+
+    #result-area #failed-sticker-container {
+        width: min(600px, calc(100vh - 300px));
+        height: min(600px, calc(100vh - 300px));
+        min-width: 400px;
+        min-height: 400px;
+        margin: 0;
+        flex-shrink: 0;
+    }
+
+    .result-right-panel {
+        display: flex !important;
+        flex-direction: column;
+        align-items: center;
+        gap: calc(var(--spacing-unit) * 2);
+        flex-shrink: 0;
+    }
+
+    .result-buttons {
+        max-width: 300px;
+    }
+}
+
+/* Mobile result area adjustments */
+@media (max-width: 700px) {
+    #result-area #failed-sticker-container {
+        width: 220px;
+        height: 220px;
+        margin-bottom: calc(var(--spacing-unit) * 2);
+    }
+
+    #result-area #game-over-text {
+        font-size: 1.8em;
+    }
+
+    #result-area .final-score-container {
+        font-size: 1.1em;
+    }
+
+    .result-buttons {
+        max-width: 220px;
+    }
+
+    .result-buttons .btn {
+        font-size: 0.95em;
+        padding: calc(var(--spacing-unit) * 1.25) calc(var(--spacing-unit) * 2);
+    }
+}
 
 /* --- Leaderboard --- */
 #leaderboard-section { margin-top: calc(var(--spacing-unit) * 4); padding-top: calc(var(--spacing-unit) * 3); }
@@ -321,6 +461,16 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
 .app-footer p { margin-bottom: calc(var(--spacing-unit) * 0.5); }
 .app-footer a { color: var(--color-info-text); text-decoration: none; }
 @media (hover: hover) { .app-footer a:hover { color: var(--color-link); text-decoration: underline; } }
+
+/* --- Hide header/footer on mobile during quiz --- */
+@media (max-width: 999px) {
+    body.quiz-active .app-header,
+    body.quiz-active .app-footer,
+    body.quiz-result .app-header,
+    body.quiz-result .app-footer {
+        display: none !important;
+    }
+}
 
 /* --- Legal/About Page Specific Styles --- */
 .legal-container { max-width: 800px; margin: calc(var(--spacing-unit) * 3) auto; padding: calc(var(--spacing-unit) * 2) calc(var(--spacing-unit) * 3); background-color: #fff; border-radius: var(--border-radius); box-shadow: 0 2px 5px rgba(0,0,0,0.05); text-align: left; }


### PR DESCRIPTION
- Desktop: Two-column layout matching quiz game (sticker left, info right)
- Mobile: Hide header/footer during quiz, vertical stacked layout
- Add "Game Over!" with red flashing animation
- Add "Better than X% players" dynamic calculation based on best scores
- Add "View sticker info" button linking to sticker page
- Play Again now fully reloads page to clear previous state
- Reorganize result buttons: leaderboard, play again, sticker info