### PR TITLE
Fix quiz end screen - sticker stays in place, add tooltips

### DIFF
--- a/quiz.html
+++ b/quiz.html
@@ -105,26 +105,18 @@
                  <div id="options" class="button-group options-group">
                  </div>
              </div>
-         </div>
-
-        <div id="result-area" style="display: none;">
-             <div id="failed-sticker-container">
-                 <img id="failed-sticker-image" src="" alt="Failed Sticker">
-             </div>
-             <div class="result-right-panel">
+             <div class="result-right-panel" style="display: none;">
                  <div class="result-info">
                      <h2 id="game-over-text">Game Over!</h2>
                      <p class="final-score-container">Your final score: <span id="final-score">0</span></p>
                  </div>
                  <div class="result-buttons">
-                     <button id="result-leaderboard-button" class="btn btn-secondary btn-large">Better than <span id="percentile-value">0</span>% players</button>
+                     <button id="result-leaderboard-button" class="btn btn-secondary btn-large" title="View leaderboard">Better than <strong><span id="percentile-value">0</span>%</strong> of players</button>
                      <button id="play-again" class="btn btn-primary btn-large">Play Again</button>
-                     <a href="/catalogue.html" id="result-sticker-info-button" class="btn btn-secondary btn-large">View sticker info</a>
+                     <a href="/catalogue.html" id="result-sticker-info-button" class="btn btn-secondary btn-large" title="Large image, geo and date">View sticker info</a>
                      <button id="result-sign-in-button" class="btn btn-secondary btn-large" style="display: none;">Sign In (hard levels, leaderboard)</button>
                  </div>
              </div>
-             <p class="rank-container personal-rank" id="personal-rank-container" style="display: none;"></p>
-             <p class="rank-container timeframe-ranks" id="timeframe-ranks-container" style="display: none;"></p>
          </div>
 
         <section id="leaderboard-section" style="display: none;">

--- a/script.js
+++ b/script.js
@@ -91,7 +91,7 @@ function getPreloadedQuestion() {
 }
 
 // ----- 3. DOM Element References -----
-let gameAreaElement, stickerImageElement, optionsContainerElement, timeLeftElement, currentScoreElement, resultAreaElement, finalScoreElement, playAgainButton, resultSignInButton, authSectionElement, loginButton, userStatusElement, logoutButton, difficultySelectionElement, loadingIndicator, errorMessageElement;
+let gameAreaElement, stickerImageElement, optionsContainerElement, timeLeftElement, currentScoreElement, finalScoreElement, playAgainButton, resultSignInButton, authSectionElement, loginButton, userStatusElement, logoutButton, difficultySelectionElement, loadingIndicator, errorMessageElement;
 let difficultyButtons;
 let leaderboardSectionElement, leaderboardListElement, closeLeaderboardButton;
 let userNicknameElement, editNicknameForm, nicknameInputElement, cancelEditNicknameButton;
@@ -100,9 +100,9 @@ let landingPageElement, landingLoginButton, landingLeaderboardButton, landingPla
 let introTextElement;
 let personalRankContainerElement, timeframeRanksContainerElement;
 let playerStatsElement, playersTotalElement, playersTodayElement;
-let failedStickerContainerElement, failedStickerImageElement;
 let leaderboardTimeFilterButtons, leaderboardDifficultyFilterButtons;
 let gameOverTextElement, percentileValueElement, resultStickerInfoButton;
+let gameRightPanelElement, resultRightPanelElement;
 
 // Flag to track if event listeners have been added
 let eventListenersAdded = false;
@@ -115,7 +115,6 @@ function initializeDOMElements(isRetry = false) {
     timeLeftElement = document.getElementById('time-left');
     currentScoreElement = document.getElementById('current-score');
     scoreDisplayElement = document.getElementById('score');
-    resultAreaElement = document.getElementById('result-area');
     finalScoreElement = document.getElementById('final-score');
     personalRankContainerElement = document.getElementById('personal-rank-container');
     timeframeRanksContainerElement = document.getElementById('timeframe-ranks-container');
@@ -146,21 +145,22 @@ function initializeDOMElements(isRetry = false) {
     playerStatsElement = document.getElementById('player-stats-element');
     playersTotalElement = document.getElementById('players-total');
     playersTodayElement = document.getElementById('players-today');
-    failedStickerContainerElement = document.getElementById('failed-sticker-container');
-    failedStickerImageElement = document.getElementById('failed-sticker-image');
     gameOverTextElement = document.getElementById('game-over-text');
     percentileValueElement = document.getElementById('percentile-value');
     resultStickerInfoButton = document.getElementById('result-sticker-info-button');
+    gameRightPanelElement = document.querySelector('.game-right-panel');
+    resultRightPanelElement = document.querySelector('.result-right-panel');
 
     const elements = {
         gameAreaElement, stickerImageElement, optionsContainerElement, timeLeftElement,
-        currentScoreElement, scoreDisplayElement, resultAreaElement, finalScoreElement,
+        currentScoreElement, scoreDisplayElement, finalScoreElement,
         playAgainButton, resultSignInButton, authSectionElement, loginButton,
         userStatusElement, userNicknameElement, logoutButton, difficultySelectionElement,
         leaderboardSectionElement, leaderboardListElement, closeLeaderboardButton,
         loadingIndicator, errorMessageElement, editNicknameForm, nicknameInputElement,
         cancelEditNicknameButton, landingPageElement, landingLoginButton,
-        landingLeaderboardButton, landingPlayEasyButton, introTextElement
+        landingLeaderboardButton, landingPlayEasyButton, introTextElement,
+        gameRightPanelElement, resultRightPanelElement
     };
 
     let allFound = true;
@@ -298,7 +298,6 @@ function updateAuthStateUI(user) {
     // Hide ALL sections first
     difficultySelectionElement.style.cssText = 'display: none !important;';
     gameAreaElement.style.cssText = 'display: none !important;';
-    resultAreaElement.style.cssText = 'display: none !important;';
     leaderboardSectionElement.style.cssText = 'display: none !important;';
     landingPageElement.style.cssText = 'display: none !important;';
     introTextElement.style.cssText = 'display: none !important;';
@@ -560,7 +559,7 @@ async function getStickerCount(difficulty) {
 
 // ----- 7. Display Question Function -----
 async function displayQuestion(questionData) {
-    if (!questionData || !stickerImageElement || !optionsContainerElement || !timeLeftElement || !currentScoreElement || !gameAreaElement || !resultAreaElement) {
+    if (!questionData || !stickerImageElement || !optionsContainerElement || !timeLeftElement || !currentScoreElement || !gameAreaElement) {
         showError("Error displaying question.");
         endGame();
         return;
@@ -624,7 +623,9 @@ async function displayQuestion(questionData) {
     }
     if (currentScoreElement) currentScoreElement.textContent = currentScore;
     if (gameAreaElement) gameAreaElement.style.display = 'block';
-    if (resultAreaElement) resultAreaElement.style.display = 'none';
+    // Show game panel, hide result panel
+    if (gameRightPanelElement) gameRightPanelElement.style.display = '';
+    if (resultRightPanelElement) resultRightPanelElement.style.display = 'none';
 
     startTimer();
 
@@ -756,12 +757,11 @@ function stopTimer() {
 function showDifficultySelection() {
     hideError();
 
-    if (!difficultySelectionElement || !gameAreaElement || !resultAreaElement || !leaderboardSectionElement || !landingPageElement || !introTextElement) {
+    if (!difficultySelectionElement || !gameAreaElement || !leaderboardSectionElement || !landingPageElement || !introTextElement) {
         if (!initializeDOMElements(true)) return;
     }
 
     if (gameAreaElement) gameAreaElement.style.display = 'none';
-    if (resultAreaElement) resultAreaElement.style.display = 'none';
     if (leaderboardSectionElement) leaderboardSectionElement.style.display = 'none';
 
     if (introTextElement) introTextElement.style.display = 'block';
@@ -819,7 +819,7 @@ async function startGame() {
         return;
     }
 
-    if (!gameAreaElement || !currentScoreElement || !resultAreaElement || !optionsContainerElement) {
+    if (!gameAreaElement || !currentScoreElement || !optionsContainerElement) {
         if (!initializeDOMElements()) {
             handleCriticalError("Failed init.");
             return;
@@ -833,11 +833,9 @@ async function startGame() {
     currentScore = 0;
     if (currentScoreElement) currentScoreElement.textContent = 0;
 
-    if (resultAreaElement) {
-        const msg = resultAreaElement.querySelector('.save-message');
-        if (msg) msg.remove();
-        resultAreaElement.style.display = 'none';
-    }
+    // Reset panels for new game
+    if (gameRightPanelElement) gameRightPanelElement.style.display = '';
+    if (resultRightPanelElement) resultRightPanelElement.style.display = 'none';
 
     if (difficultySelectionElement) difficultySelectionElement.style.display = 'none';
     if (introTextElement) introTextElement.style.display = 'none';
@@ -870,12 +868,7 @@ async function loadNextQuestion(isQuickTransition = false) {
         displayQuestion(questionData);
     } else {
         console.error("loadNextQuestion: Failed. Ending game.");
-        if (gameAreaElement) gameAreaElement.style.display = 'none';
-        if (resultAreaElement) {
-            resultAreaElement.style.display = 'block';
-            if (finalScoreElement) finalScoreElement.textContent = currentScore;
-        }
-        if (introTextElement) introTextElement.style.display = 'block';
+        endGame();
     }
 }
 
@@ -1139,13 +1132,9 @@ function endGame() {
         gameOverTextElement.classList.add('game-over-animated');
     }
 
-    if (gameAreaElement) gameAreaElement.style.display = 'none';
-
-    if (resultAreaElement) {
-        const msg = resultAreaElement.querySelector('.save-message');
-        if (msg) msg.remove();
-        resultAreaElement.style.display = 'block';
-    }
+    // Switch from game panel to result panel (sticker stays in place)
+    if (gameRightPanelElement) gameRightPanelElement.style.display = 'none';
+    if (resultRightPanelElement) resultRightPanelElement.style.display = 'flex';
 
     if (resultSignInButton) {
         resultSignInButton.style.display = currentUser ? 'none' : 'inline-block';
@@ -1153,12 +1142,6 @@ function endGame() {
 
     if (difficultySelectionElement) difficultySelectionElement.style.display = 'none';
     if (introTextElement) introTextElement.style.display = 'none';
-
-    // Display the failed sticker (the one the player didn't guess correctly)
-    if (currentQuestionData && failedStickerContainerElement && failedStickerImageElement) {
-        failedStickerImageElement.src = currentQuestionData.imageUrl;
-        failedStickerImageElement.alt = currentQuestionData.correctAnswer;
-    }
 
     // Update sticker info button to link to the failed club's page
     if (resultStickerInfoButton && currentQuestionData && currentQuestionData.clubId) {
@@ -1181,10 +1164,6 @@ function endGame() {
     if (leaderboardButton) {
         leaderboardButton.onclick = () => window.location.href = '/leaderboard.html';
     }
-
-    // Hide old rank containers (not shown in new design)
-    if (personalRankContainerElement) personalRankContainerElement.style.display = 'none';
-    if (timeframeRanksContainerElement) timeframeRanksContainerElement.style.display = 'none';
 
     saveScore();
 }
@@ -1340,13 +1319,12 @@ function handleDifficultyFilterChange(event) {
 function openLeaderboard() {
     hideError();
 
-    if (!leaderboardSectionElement || !landingPageElement || !gameAreaElement || !resultAreaElement || !difficultySelectionElement || !introTextElement) {
+    if (!leaderboardSectionElement || !landingPageElement || !gameAreaElement || !difficultySelectionElement || !introTextElement) {
         handleCriticalError("UI Error opening leaderboard.");
         return;
     }
 
     if (gameAreaElement) gameAreaElement.style.display = 'none';
-    if (resultAreaElement) resultAreaElement.style.display = 'none';
     if (difficultySelectionElement) difficultySelectionElement.style.display = 'none';
     if (landingPageElement) landingPageElement.style.display = 'none';
     if (introTextElement) introTextElement.style.display = 'none';

--- a/style.css
+++ b/style.css
@@ -266,38 +266,19 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
 #sticker-image.fade-in { animation: fadeIn 0.4s ease-out; }
 
 
-/* --- Result Area --- */
-#result-area {
-    margin-top: calc(var(--spacing-unit) * 2);
-    padding: calc(var(--spacing-unit) * 2);
-    text-align: center;
-}
+/* --- Result Panel (inside game-area, sticker stays in place) --- */
 
-/* Failed sticker container in result area */
-#result-area #failed-sticker-container {
-    width: 300px;
-    height: 300px;
-    margin: 0 auto calc(var(--spacing-unit) * 3) auto;
-    background-color: var(--color-secondary-bg);
-    border: 1px solid var(--color-border);
-    border-radius: var(--border-radius);
-    overflow: hidden;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-#result-area #failed-sticker-image {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-}
-
-/* Result right panel (mobile: flows naturally) */
+/* Result right panel - same positioning as game-right-panel */
 .result-right-panel {
-    display: flex;
+    display: none; /* Hidden by default, shown when game ends */
     flex-direction: column;
     align-items: center;
     gap: calc(var(--spacing-unit) * 2);
+}
+
+/* When visible, result panel uses flex */
+.result-right-panel[style*="flex"] {
+    display: flex !important;
 }
 
 /* Result info section */
@@ -306,7 +287,7 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
 }
 
 /* Game Over text with red color and animation */
-#result-area #game-over-text {
+#game-over-text {
     font-size: 2em;
     font-weight: 700;
     color: var(--color-error);
@@ -325,13 +306,13 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
     100% { transform: scale(1); opacity: 1; }
 }
 
-#result-area .final-score-container {
+.result-right-panel .final-score-container {
     font-size: 1.3em;
     font-weight: 500;
     color: var(--color-info-text);
     margin: 0;
 }
-#result-area #final-score {
+.result-right-panel #final-score {
     font-weight: 700;
     color: var(--color-accent-darker);
 }
@@ -355,38 +336,9 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
     box-sizing: border-box;
 }
 
-#result-area .rank-container {
-    display: none; /* Hidden in new design */
-}
-
-/* Desktop horizontal layout for result area */
+/* Desktop: result panel matches game panel positioning */
 @media (min-width: 1000px) {
-    #result-area[style*="block"] {
-        display: flex !important;
-        flex-direction: row;
-        align-items: flex-start;
-        justify-content: center;
-        gap: calc(var(--spacing-unit) * 4);
-        margin-top: calc(var(--spacing-unit) * 2);
-        width: calc(100vw - var(--spacing-unit) * 4);
-        max-width: 1000px;
-        margin-left: auto;
-        margin-right: auto;
-        position: relative;
-        left: 50%;
-        transform: translateX(-50%);
-    }
-
-    #result-area #failed-sticker-container {
-        width: min(600px, calc(100vh - 300px));
-        height: min(600px, calc(100vh - 300px));
-        min-width: 400px;
-        min-height: 400px;
-        margin: 0;
-        flex-shrink: 0;
-    }
-
-    .result-right-panel {
+    .result-right-panel[style*="flex"] {
         display: flex !important;
         flex-direction: column;
         align-items: center;
@@ -399,19 +351,13 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
     }
 }
 
-/* Mobile result area adjustments */
+/* Mobile result panel adjustments */
 @media (max-width: 700px) {
-    #result-area #failed-sticker-container {
-        width: 220px;
-        height: 220px;
-        margin-bottom: calc(var(--spacing-unit) * 2);
-    }
-
-    #result-area #game-over-text {
+    #game-over-text {
         font-size: 1.8em;
     }
 
-    #result-area .final-score-container {
+    .result-right-panel .final-score-container {
         font-size: 1.1em;
     }
 


### PR DESCRIPTION
- Restructure HTML so result panel is inside game-area
- Sticker container no longer moves on game end
- Switch panels instead of reloading sticker
- Add "of players" to leaderboard button text
- Make percentage bold in "Better than X% of players"
- Add tooltip "View leaderboard" to leaderboard button
- Add tooltip "Large image, geo and date" to sticker info button