### PR TITLE
Redesign sticker detail page with two-column layout

### DIFF
--- a/catalogue.js
+++ b/catalogue.js
@@ -867,21 +867,21 @@ async function loadStickerDetails(stickerId) {
                 updateBreadcrumbs([{ text: `All Countries (${totalCountriesInCatalogue})`, link: 'catalogue.html' }]);
             }
 
-            // Navigation links for prev/next stickers (positioned below image)
+            // Navigation links for prev/next stickers (positioned below image in left column)
             let navigationHtml = '';
             if (prevStickerId !== null || nextStickerId !== null) {
-                navigationHtml = '<div style="display: flex; justify-content: space-between; align-items: center; margin-top: 16px; margin-bottom: 24px; gap: 16px;">';
+                navigationHtml = '<div class="sticker-nav-buttons">';
 
                 if (prevStickerId !== null) {
-                    navigationHtml += `<a href="catalogue.html?sticker_id=${prevStickerId}" style="color: var(--color-info-text); text-decoration: none; font-size: 1.1em; font-weight: 500;">← #${prevStickerId}</a>`;
+                    navigationHtml += `<a href="catalogue.html?sticker_id=${prevStickerId}" class="btn btn-nav sticker-nav-btn">← #${prevStickerId}</a>`;
                 } else {
-                    navigationHtml += '<span style="visibility: hidden;">← #0</span>';
+                    navigationHtml += '<span class="sticker-nav-placeholder"></span>';
                 }
 
                 if (nextStickerId !== null) {
-                    navigationHtml += `<a href="catalogue.html?sticker_id=${nextStickerId}" style="color: var(--color-info-text); text-decoration: none; font-size: 1.1em; font-weight: 500;">#${nextStickerId} →</a>`;
+                    navigationHtml += `<a href="catalogue.html?sticker_id=${nextStickerId}" class="btn btn-nav sticker-nav-btn">#${nextStickerId} →</a>`;
                 } else {
-                    navigationHtml += '<span style="visibility: hidden;">#0 →</span>';
+                    navigationHtml += '<span class="sticker-nav-placeholder"></span>';
                 }
 
                 navigationHtml += '</div>';
@@ -890,55 +890,65 @@ async function loadStickerDetails(stickerId) {
             // Use optimized detail image URL, but keep original for full-size view
             const detailImageUrl = SharedUtils.getDetailImageUrl(sticker.image_url);
 
-            // Build hunted info section
-            let huntedInfoHtml = '';
+            // Build right column info
             const hasLocation = sticker.location && sticker.location.trim() !== '';
             const hasDate = sticker.found != null;
             const hasCoordinates = sticker.latitude != null && sticker.longitude != null;
 
-            if (hasDate && hasLocation) {
-                // Format date as "24 August 2025"
+            // Format date if available
+            let formattedDate = '';
+            if (hasDate) {
                 const dateObj = new Date(sticker.found);
-                const formattedDate = dateObj.toLocaleDateString('en-GB', {
+                formattedDate = dateObj.toLocaleDateString('en-GB', {
                     day: 'numeric',
                     month: 'long',
                     year: 'numeric'
                 });
-                huntedInfoHtml = `
-                    <div class="sticker-detail-info">
-                        <p>📍 The sticker was hunted on <strong>${formattedDate}</strong> in <strong>${sticker.location}</strong>.</p>
-                    </div>
-                `;
-            } else if (hasLocation) {
-                huntedInfoHtml = `
-                    <div class="sticker-detail-info">
-                        <p>📍 The sticker was hunted in <strong>${sticker.location}</strong>.</p>
-                    </div>
-                `;
             }
 
-            // Build map section HTML if coordinates are available
-            const mapSectionHtml = hasCoordinates ? `
-                <div class="sticker-map-section">
-                    <div id="sticker-map" class="sticker-map-container"></div>
-                    <div class="view-map-btn-container">
-                        <a href="/map.html" class="btn btn-nav">View Full Map</a>
+            // Build right panel content (similar to quiz result panel)
+            const clubDisplayName = sticker.clubs ? sticker.clubs.name : 'Unknown Club';
+
+            let rightPanelHtml = `
+                <div class="sticker-detail-right-panel">
+                    <div class="sticker-detail-info-block">
+                        <h2 class="sticker-detail-club-name">${clubDisplayName}</h2>
+                        <p class="sticker-detail-id">#${sticker.id}</p>
+                        ${hasDate ? `<p class="sticker-detail-date">Hunted on ${formattedDate}</p>` : ''}
+                        ${hasLocation ? `<p class="sticker-detail-location">${sticker.location}</p>` : ''}
                     </div>
                 </div>
-            ` : '';
+            `;
+
+            // Build map section HTML if coordinates are available (full width below two columns)
+            const mapSectionHtml = hasCoordinates ? `
+                <div class="sticker-map-section sticker-map-full-width">
+                    <div id="sticker-map" class="sticker-map-container"></div>
+                    <div class="sticker-detail-actions">
+                        <a href="/map.html" class="btn btn-nav">View Full Map</a>
+                        <a href="/quiz.html" class="btn btn-nav">Play Quiz</a>
+                    </div>
+                </div>
+            ` : `
+                <div class="sticker-detail-actions sticker-actions-no-map">
+                    <a href="/quiz.html" class="btn btn-nav">Play Quiz</a>
+                </div>
+            `;
 
             contentBodyHtml = `
-                <div class="sticker-detail-view">
-                    <div class="sticker-detail-image-container" onclick="window.open('${sticker.image_url}', '_blank')">
-                        <img src="${detailImageUrl}"
-                             alt="Sticker ${sticker.id} ${sticker.clubs ? `- ${sticker.clubs.name}` : ''}"
-                             class="sticker-detail-image"
-                             decoding="async">
+                <div class="sticker-detail-view sticker-detail-two-column">
+                    <div class="sticker-detail-left-column">
+                        <div class="sticker-detail-image-container" onclick="window.open('${sticker.image_url}', '_blank')">
+                            <img src="${detailImageUrl}"
+                                 alt="Sticker ${sticker.id} ${sticker.clubs ? `- ${sticker.clubs.name}` : ''}"
+                                 class="sticker-detail-image"
+                                 decoding="async">
+                        </div>
+                        ${navigationHtml}
                     </div>
-                    ${navigationHtml}
-                    ${huntedInfoHtml}
-                    ${mapSectionHtml}
+                    ${rightPanelHtml}
                 </div>
+                ${mapSectionHtml}
             `;
         }
         contentDiv.innerHTML = contentBodyHtml;

--- a/style.css
+++ b/style.css
@@ -690,7 +690,7 @@ body.quiz-result .result-right-panel {
     }
 }
 
-/* Sticker detail page styles */
+/* Sticker Detail - Two Column Layout (like quiz end screen) */
 .sticker-detail-view {
     display: flex;
     flex-direction: column;
@@ -698,10 +698,24 @@ body.quiz-result .result-right-panel {
     text-align: left;
 }
 
+.sticker-detail-two-column {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: center;
+    gap: calc(var(--spacing-unit) * 4);
+    width: 100%;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.sticker-detail-left-column {
+    flex-shrink: 0;
+}
+
 .sticker-detail-image-container {
     width: 300px;
     height: 300px;
-    margin: 0 auto calc(var(--spacing-unit) * 3) auto;
     background-color: var(--color-secondary-bg);
     border: 1px solid var(--color-border);
     border-radius: var(--border-radius);
@@ -746,33 +760,108 @@ body.quiz-result .result-right-panel {
     pointer-events: none;
 }
 
-.sticker-detail-info {
+/* Navigation buttons below sticker */
+.sticker-nav-buttons {
+    display: flex;
+    justify-content: space-between;
+    gap: calc(var(--spacing-unit) * 2);
+    margin-top: calc(var(--spacing-unit) * 2);
     width: 100%;
-    max-width: 600px;
+}
+
+.sticker-nav-btn {
+    flex: 1;
+    text-align: center;
+}
+
+.sticker-nav-placeholder {
+    flex: 1;
+}
+
+/* Right panel - info block */
+.sticker-detail-right-panel {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: calc(var(--spacing-unit) * 2);
+    padding-top: calc(var(--spacing-unit) * 2);
+}
+
+.sticker-detail-info-block {
     text-align: left;
 }
 
-.sticker-detail-info p {
-    font-size: 1.2em;
-    margin-bottom: calc(var(--spacing-unit) * 2);
-    line-height: 1.6;
+.sticker-detail-club-name {
+    font-size: 1.3em;
+    font-weight: 700;
     color: var(--color-text);
+    margin: 0 0 calc(var(--spacing-unit) * 0.5) 0;
 }
 
-.sticker-detail-info strong {
-    font-weight: 600;
-    color: var(--color-text);
+.sticker-detail-id {
+    font-size: 1.3em;
+    font-weight: 500;
+    color: var(--color-info-text);
+    margin: 0 0 calc(var(--spacing-unit) * 2) 0;
 }
 
-@media (max-width: 600px) {
-    .sticker-detail-image-container {
-        width: 90%;
-        height: auto;
-        aspect-ratio: 1 / 1;
+.sticker-detail-id span {
+    font-weight: 700;
+    color: var(--color-accent-darker);
+}
+
+.sticker-detail-date,
+.sticker-detail-location {
+    font-size: 1em;
+    font-weight: 400;
+    color: var(--color-info-text);
+    margin: 0 0 calc(var(--spacing-unit) * 1) 0;
+}
+
+/* Action buttons below map or content */
+.sticker-detail-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: calc(var(--spacing-unit) * 1.5);
+    margin-top: calc(var(--spacing-unit) * 3);
+    width: 100%;
+}
+
+.sticker-detail-actions .btn {
+    width: 100%;
+    max-width: 300px;
+}
+
+.sticker-actions-no-map {
+    margin-top: calc(var(--spacing-unit) * 4);
+}
+
+/* Mobile: stack columns vertically */
+@media (max-width: 700px) {
+    .sticker-detail-two-column {
+        flex-direction: column;
+        align-items: center;
+        gap: calc(var(--spacing-unit) * 2);
     }
 
-    .sticker-detail-info p {
-        font-size: 1em;
+    .sticker-detail-image-container {
+        width: 280px;
+        height: 280px;
+    }
+
+    .sticker-detail-right-panel {
+        align-items: center;
+        text-align: center;
+        padding-top: 0;
+    }
+
+    .sticker-detail-info-block {
+        text-align: center;
+    }
+
+    .sticker-nav-buttons {
+        max-width: 280px;
     }
 }
 
@@ -782,6 +871,12 @@ body.quiz-result .result-right-panel {
     max-width: 600px;
     margin-top: calc(var(--spacing-unit) * 3);
     text-align: left;
+}
+
+/* Full width map below two-column layout */
+.sticker-map-full-width {
+    max-width: 100%;
+    margin-top: calc(var(--spacing-unit) * 4);
 }
 
 .sticker-map-label {


### PR DESCRIPTION
Layout changes (matching quiz end screen):
- Left column: sticker image (300x300) with nav buttons below
- Right column: club name, sticker ID, hunted date, location
- Full-width map below the two columns
- Action buttons: View Full Map, Play Quiz

Style updates:
- Navigation buttons use unified btn-nav style
- Responsive: stacks vertically on mobile (< 700px)
- Same image container size as quiz (300x300 desktop, 280x280 mobile)