### PR TITLE
Fix sticker detail: match quiz sticker size and hide heading

### DIFF
--- a/catalogue.js
+++ b/catalogue.js
@@ -820,7 +820,7 @@ async function loadStickerDetails(stickerId) {
                     const countryDetail = countryCodeToDetails_Generic[sticker.clubs.country.toUpperCase()];
                     countryDisplayNameForBreadcrumb = countryDetail ? countryDetail.name : sticker.clubs.country;
                 }
-                if (mainHeading) mainHeading.textContent = `Sticker #${sticker.id} - ${clubName}`;
+                if (mainHeading) mainHeading.style.display = 'none'; // Hide heading - info shown in right column
                 document.title = `Sticker #${sticker.id} - ${clubName} - ${countryDisplayNameForBreadcrumb} - Sticker Catalogue`;
                 updateCanonicalUrl(`https://stickerhunt.club/catalogue.html?sticker_id=${sticker.id}`);
                 updateMetaDescription(`Football sticker #${sticker.id} from ${clubName}, ${countryDisplayNameForBreadcrumb}. View this sticker in our collection.`);
@@ -863,7 +863,7 @@ async function loadStickerDetails(stickerId) {
                     }
                 }
             } else {
-                if (mainHeading) mainHeading.textContent = `Sticker #${sticker.id}`;
+                if (mainHeading) mainHeading.style.display = 'none'; // Hide heading - info shown in right column
                 updateBreadcrumbs([{ text: `All Countries (${totalCountriesInCatalogue})`, link: 'catalogue.html' }]);
             }
 

--- a/style.css
+++ b/style.css
@@ -698,6 +698,33 @@ body.quiz-result .result-right-panel {
     text-align: left;
 }
 
+/* Desktop: expand to match quiz layout width */
+@media (min-width: 1000px) {
+    .sticker-detail-two-column {
+        display: flex;
+        flex-direction: row;
+        align-items: flex-start;
+        justify-content: center;
+        gap: calc(var(--spacing-unit) * 4);
+        width: calc(100vw - var(--spacing-unit) * 4);
+        max-width: 1000px;
+        margin-left: auto;
+        margin-right: auto;
+        position: relative;
+        left: 50%;
+        transform: translateX(-50%);
+    }
+
+    .sticker-detail-image-container {
+        /* Match quiz sticker size exactly */
+        width: min(600px, calc(100vh - 300px));
+        height: min(600px, calc(100vh - 300px));
+        min-width: 400px;
+        min-height: 400px;
+    }
+}
+
+/* Tablet and smaller: default layout */
 .sticker-detail-two-column {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
- Desktop sticker size now matches quiz: min(600px, calc(100vh - 300px))
- Minimum size 400x400 like quiz
- Container width expanded to 1000px like quiz layout
- Hidden h1 heading - club info shown in right column instead
- Uses same breakout technique as quiz for wider layout