### PR TITLE
Add Time To Run game mode with 99-second countdown

### DIFF
--- a/leaderboard.html
+++ b/leaderboard.html
@@ -98,6 +98,12 @@
                     <p>Loading...</p>
                 </div>
             </section>
+            <section class="leaderboard-section leaderboard-section-ttr" id="leaderboard-ttr">
+                <h2>Time To Run</h2>
+                <div id="leaderboard-table-ttr">
+                    <p>Loading...</p>
+                </div>
+            </section>
         </div>
 
         <div class="leaderboard-actions">

--- a/quiz.html
+++ b/quiz.html
@@ -68,6 +68,7 @@
         </div>
         <div id="landing-page" style="display: none;">
             <button id="landing-play-easy-button" class="btn btn-primary btn-large">Play (easy level)</button>
+            <button id="landing-ttr-button" class="btn btn-primary btn-large">Time To Run</button>
             <button id="landing-login-button" class="btn btn-secondary btn-large google-login">
                 <span>Sign in (middle & hard levels)</span>
             </button>
@@ -85,6 +86,9 @@
                 </div>
                 <div class="difficulty-option">
                     <button class="btn btn-primary btn-large difficulty-button" data-difficulty="3">Hard</button> <p class="difficulty-description">For real experts. My respect!</p>
+                </div>
+                <div class="difficulty-option ttr-option">
+                    <button id="ttr-mode-button" class="btn btn-primary btn-large">Time To Run</button> <p class="difficulty-description">99 seconds. All difficulties. How much can you score?</p>
                 </div>
             </div>
             <div class="leaderboard-action">

--- a/shared.js
+++ b/shared.js
@@ -18,7 +18,12 @@ const CONFIG = {
 
     // Game settings
     TIMER_DURATION: 10,
+    TTR_TIMER_DURATION: 99,  // Time To Run mode: 99 seconds total
     LEADERBOARD_LIMIT: 10,
+
+    // Game modes
+    GAME_MODE_CLASSIC: 'classic',
+    GAME_MODE_TTR: 'ttr',  // Time To Run mode
 
     // Nickname settings
     NICKNAME_MIN_LENGTH: 3,

--- a/style.css
+++ b/style.css
@@ -2099,3 +2099,74 @@ body.home-page #app-logo {
         font-size: 1em;
     }
 }
+
+/* ------------------------------ */
+/* Time To Run Mode Styles        */
+/* ------------------------------ */
+
+/* TTR difficulty border colors on options container */
+.options-group.ttr-difficulty-1 button {
+    border: 2px solid #28a745; /* Green for Easy */
+}
+
+.options-group.ttr-difficulty-2 button {
+    border: 2px solid #ffc107; /* Yellow for Medium */
+}
+
+.options-group.ttr-difficulty-3 button {
+    border: 2px solid #dc3545; /* Red for Hard */
+}
+
+/* TTR timer flashing animation on last 10 seconds */
+#time-left.ttr-flash {
+    animation: ttr-timer-flash 0.5s ease-in-out infinite;
+}
+
+@keyframes ttr-timer-flash {
+    0%, 100% { color: var(--color-error); opacity: 1; }
+    50% { color: var(--color-error); opacity: 0.4; }
+}
+
+/* TTR mode body indicator for potential styling */
+body.ttr-mode .game-info #timer {
+    color: var(--color-text);
+}
+
+/* Leaderboard 4-column grid for TTR */
+.leaderboard-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: calc(var(--spacing-unit) * 4);
+}
+
+/* TTR section in leaderboard */
+.leaderboard-section-ttr h2 {
+    color: var(--color-accent-darker);
+}
+
+/* Tablet: 4 columns with smaller gaps */
+@media (max-width: 900px) {
+    .leaderboard-grid {
+        grid-template-columns: repeat(2, 1fr);
+        gap: calc(var(--spacing-unit) * 3);
+    }
+}
+
+/* Mobile: stack all columns */
+@media (max-width: 600px) {
+    .leaderboard-grid {
+        grid-template-columns: 1fr;
+        gap: calc(var(--spacing-unit) * 3);
+    }
+
+    .leaderboard-section-ttr {
+        margin-top: calc(var(--spacing-unit) * 2);
+    }
+}
+
+/* TTR option in difficulty selection - same style as others */
+.difficulty-option.ttr-option {
+    margin-top: calc(var(--spacing-unit) * 1);
+    padding-top: calc(var(--spacing-unit) * 2);
+    border-top: 1px dashed var(--color-border);
+}


### PR DESCRIPTION
- Add new TTR game mode with 99 seconds total timer (vs 10 seconds per sticker in classic)
- Implement sticker rotation pattern: 3 easy (1pt), 2 medium (2pt), 1 hard (3pt), repeat
- Add difficulty-based colored borders on answer buttons (green/yellow/red)
- Flash timer red on last 10 seconds
- Wrong answers don't end game - continue until time runs out
- Add TTR column to leaderboard page (4th column on desktop, stacked on mobile)
- Add TTR button to difficulty selection and landing page
- Store game_mode in scores table to separate classic from TTR results