### PR TITLE
Fix Time To Run mode issues

### DIFF
--- a/leaderboard.js
+++ b/leaderboard.js
@@ -123,9 +123,6 @@ async function fetchLeaderboardData(timeframe, difficulty) {
             .select(`score, created_at, user_id, profiles ( username )`)
             .eq('difficulty', difficulty);
 
-        // Filter out TTR mode scores (only show classic mode in difficulty columns)
-        query = query.or('game_mode.is.null,game_mode.eq.classic');
-
         if (fromDate) {
             query = query.gte('created_at', fromDate);
         }
@@ -160,10 +157,11 @@ async function fetchLeaderboardDataTTR(timeframe) {
         // Use shared calculateTimeRange for consistent timezone handling
         const { fromDate, toDate } = SharedUtils.calculateTimeRange(timeframe);
 
+        // TTR mode uses difficulty=null to identify TTR scores
         let query = supabaseClient
             .from('scores')
             .select(`score, created_at, user_id, profiles ( username )`)
-            .eq('game_mode', 'ttr');
+            .is('difficulty', null);
 
         if (fromDate) {
             query = query.gte('created_at', fromDate);

--- a/quiz.html
+++ b/quiz.html
@@ -88,7 +88,8 @@
                     <button class="btn btn-primary btn-large difficulty-button" data-difficulty="3">Hard</button> <p class="difficulty-description">For real experts. My respect!</p>
                 </div>
                 <div class="difficulty-option ttr-option">
-                    <button id="ttr-mode-button" class="btn btn-primary btn-large">Time To Run</button> <p class="difficulty-description">99 seconds. All difficulties. How much can you score?</p>
+                    <button id="ttr-mode-button" class="btn btn-primary btn-large difficulty-button">Time To Run</button>
+                    <p class="difficulty-description">99 seconds for all difficulties</p>
                 </div>
             </div>
             <div class="leaderboard-action">

--- a/script.js
+++ b/script.js
@@ -1446,7 +1446,7 @@ async function saveScore() {
     if (typeof currentScore !== 'number' || currentScore < 0) return;
     if (currentScore === 0) return;
 
-    // For TTR mode, difficulty is null (mixed)
+    // For TTR mode, difficulty is null (used to identify TTR scores in leaderboard)
     const difficultyToSave = currentGameMode === SharedUtils.CONFIG.GAME_MODE_TTR ? null : selectedDifficulty;
     if (currentGameMode === SharedUtils.CONFIG.GAME_MODE_CLASSIC && selectedDifficulty === null) return;
 
@@ -1459,7 +1459,6 @@ async function saveScore() {
                 user_id: currentUser.id,
                 score: currentScore,
                 difficulty: difficultyToSave,
-                game_mode: currentGameMode,
                 country_code: null
             });
 


### PR DESCRIPTION
- Fix TTR button styling: add difficulty-button class for consistent width
- Update description text to "99 seconds for all difficulties"
- Remove game_mode column usage (column doesn't exist in DB)
- Use difficulty=null to identify TTR mode scores instead
- Fix leaderboard queries to work without game_mode column