### PR TITLE
Switch maps to CartoDB Voyager tiles for English labels

### DIFF
--- a/catalogue.js
+++ b/catalogue.js
@@ -1275,10 +1275,10 @@ function initializeStickerMap(latitude, longitude, clubName, currentStickerId, n
         scrollWheelZoom: false // Disable scroll zoom for better UX
     }).setView([latitude, longitude], 15);
 
-    // Add OpenStreetMap tiles
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    // Add CartoDB Voyager tiles (English labels)
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
         maxZoom: 19,
-        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
     }).addTo(map);
 
     // Create custom icons
@@ -1390,10 +1390,10 @@ function initializeClubMap(stickers, clubName) {
     // Fit map to bounds with padding
     map.fitBounds(bounds, { padding: [30, 30] });
 
-    // Add OpenStreetMap tiles
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    // Add CartoDB Voyager tiles (English labels)
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
         maxZoom: 19,
-        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
     }).addTo(map);
 
     // Create marker icon

--- a/map.js
+++ b/map.js
@@ -109,10 +109,10 @@ async function initializeGlobalMap() {
         scrollWheelZoom: false
     }).setView([50.0, 10.0], 4); // Center on Europe
 
-    // Add OpenStreetMap tiles
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    // Add CartoDB Voyager tiles (English labels)
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
         maxZoom: 19,
-        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
     }).addTo(map);
 
     // Create inactive icon for stickers


### PR DESCRIPTION
Replace OpenStreetMap tiles with CartoDB Voyager tiles across all maps (global map and catalogue detail maps) to ensure consistent English labels instead of mixed local languages.