### PR TITLE
Move TTR difficulty border from buttons to sticker container

### DIFF
--- a/script.js
+++ b/script.js
@@ -625,12 +625,17 @@ async function displayQuestion(questionData) {
         ? `ttr-difficulty-${questionData.difficulty || currentStickerDifficulty}`
         : '';
 
-    optionsContainerElement.innerHTML = '';
-    // Add TTR difficulty class to options container
-    optionsContainerElement.className = 'button-group options-group';
-    if (difficultyClass) {
-        optionsContainerElement.classList.add(difficultyClass);
+    // Add TTR difficulty class to sticker container for border styling
+    const stickerContainer = document.getElementById('sticker-container');
+    if (stickerContainer) {
+        stickerContainer.classList.remove('ttr-difficulty-1', 'ttr-difficulty-2', 'ttr-difficulty-3');
+        if (difficultyClass) {
+            stickerContainer.classList.add(difficultyClass);
+        }
     }
+
+    optionsContainerElement.innerHTML = '';
+    optionsContainerElement.className = 'button-group options-group';
 
     if (questionData.options && Array.isArray(questionData.options)) {
         questionData.options.forEach((optionText) => {
@@ -1389,6 +1394,12 @@ function endGame() {
 
     // Reset TTR-specific state
     ttrTimerPaused = false;
+
+    // Clear TTR difficulty border from sticker container
+    const stickerContainer = document.getElementById('sticker-container');
+    if (stickerContainer) {
+        stickerContainer.classList.remove('ttr-difficulty-1', 'ttr-difficulty-2', 'ttr-difficulty-3');
+    }
 
     // Show body class to indicate quiz is over (for hiding header/footer on mobile)
     document.body.classList.remove('quiz-active', 'ttr-mode');

--- a/style.css
+++ b/style.css
@@ -2104,17 +2104,17 @@ body.home-page #app-logo {
 /* Time To Run Mode Styles        */
 /* ------------------------------ */
 
-/* TTR difficulty border colors on options container */
-.options-group.ttr-difficulty-1 button {
-    border: 2px solid #28a745; /* Green for Easy */
+/* TTR difficulty border colors on sticker container */
+#sticker-container.ttr-difficulty-1 {
+    border: 3px solid #28a745; /* Green for Easy */
 }
 
-.options-group.ttr-difficulty-2 button {
-    border: 2px solid #ffc107; /* Yellow for Medium */
+#sticker-container.ttr-difficulty-2 {
+    border: 3px solid #ffc107; /* Yellow for Medium */
 }
 
-.options-group.ttr-difficulty-3 button {
-    border: 2px solid #dc3545; /* Red for Hard */
+#sticker-container.ttr-difficulty-3 {
+    border: 3px solid #dc3545; /* Red for Hard */
 }
 
 /* TTR timer flashing animation on last 10 seconds */


### PR DESCRIPTION
Move the colored difficulty indicator (green/yellow/red border) from answer buttons to the sticker container for less distraction during gameplay. Border is now 3px around the sticker image.