### PR TITLE
Optimize mobile quiz layout to fit all 4 buttons on screen

### DIFF
--- a/style.css
+++ b/style.css
@@ -1136,25 +1136,25 @@ body.quiz-result .result-right-panel {
     .intro-text { margin-bottom: calc(var(--spacing-unit) * 2);}
 }
 @media (max-width: 700px) {
-    #sticker-container { width: 100%; max-width: 400px; height: auto; aspect-ratio: 1; margin-bottom: calc(var(--spacing-unit) * 2); }
+    #sticker-container { width: 100%; max-width: min(400px, 55vh); height: auto; aspect-ratio: 1; margin-bottom: var(--spacing-unit); }
     #game-area { margin-top: 0; }
     .options-group {
         grid-template-columns: 1fr; /* Full width single column */
-        gap: var(--spacing-unit);
+        gap: calc(var(--spacing-unit) * 0.75);
         margin-bottom: var(--spacing-unit);
         width: 100%;
-        max-width: 400px;
+        max-width: min(400px, 55vh);
     }
     .options-group button,
     .options-group a.btn {
         width: 100%;
-        height: 56px;
-        font-size: 0.95em;
-        padding: calc(var(--spacing-unit) * 0.875) var(--spacing-unit);
+        height: 48px;
+        font-size: 0.9em;
+        padding: calc(var(--spacing-unit) * 0.5) var(--spacing-unit);
     }
-    .game-info { margin-top: var(--spacing-unit); flex-direction: row; gap: calc(var(--spacing-unit) * 3); }
-    #timer, #score { font-size: 1em; padding: calc(var(--spacing-unit)*0.5) 0; }
-    #time-left, #current-score { font-size: 1.1em; }
+    .game-info { margin-top: calc(var(--spacing-unit) * 0.5); margin-bottom: calc(var(--spacing-unit) * 0.5); flex-direction: row; gap: calc(var(--spacing-unit) * 3); }
+    #timer, #score { font-size: 0.95em; padding: calc(var(--spacing-unit)*0.25) 0; }
+    #time-left, #current-score { font-size: 1.05em; }
     .difficulty-options-container { gap: calc(var(--spacing-unit) * 1.5); }
 }
 @media (max-width: 600px) {


### PR DESCRIPTION
- Use viewport-based max-width for sticker (min of 400px or 55vh)
- Reduce margins and gaps between elements
- Decrease button height from 56px to 48px
- Make timer/score section more compact