### PR TITLE
Fix game-info to use same grid as buttons for exact alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -240,28 +240,43 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
         grid-template-columns: 1fr;
     }
     .game-info {
-        width: 100%;
+        grid-template-columns: 1fr 1fr;
         max-width: 300px;
     }
     #timer, #lives, #score {
         font-size: 0.85em;
     }
-    #timer { width: 70px; }
-    #score { width: 70px; }
 }
 .options-group button.correct-answer { background-color: var(--color-success) !important; border-color: var(--color-success) !important; color: white !important; font-weight: 600; }
 .options-group button.incorrect-answer { background-color: var(--color-error) !important; border-color: var(--color-error) !important; color: white !important; opacity: 0.7; }
 
 /* --- Game Info Timer & Score --- */
-/* Width matches options-group: 2 × 300px + gap (12px) = 612px */
+/* Uses same grid as options-group to match width exactly */
 .game-info {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    margin-top: calc(var(--spacing-unit) * 3);
-    width: calc(600px + var(--spacing-unit) * 1.5);
-    margin-left: auto;
-    margin-right: auto;
+    display: grid;
+    grid-template-columns: repeat(2, 300px);
+    gap: calc(var(--spacing-unit) * 1.5);
+    margin: calc(var(--spacing-unit) * 3) auto 0;
+    justify-content: center;
+}
+/* Timer on left edge, Score on right edge, Lives hidden in TTR */
+#timer {
+    grid-column: 1;
+    justify-self: start;
+}
+#score {
+    grid-column: 2;
+    justify-self: end;
+}
+#lives {
+    grid-column: 1 / -1;
+    justify-self: center;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+}
+.game-info {
+    position: relative;
 }
 #timer, #score, #lives {
     font-size: 0.95em;
@@ -269,11 +284,7 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
     font-weight: 500;
     white-space: nowrap;
 }
-/* Fixed widths to prevent layout shift */
-#timer { width: 90px; text-align: left; }
-#lives { width: auto; text-align: center; }
-#score { width: 90px; text-align: right; }
-#time-left {
+#time-left, #current-score {
     display: inline-block;
     min-width: 2ch;
     text-align: right;
@@ -282,17 +293,9 @@ button:disabled, .btn:disabled { cursor: not-allowed !important; background-colo
     color: var(--color-text);
     margin-left: 4px;
     vertical-align: baseline;
-    transition: color 0.3s ease;
 }
-#current-score {
-    display: inline-block;
-    min-width: 2ch;
-    text-align: right;
-    font-weight: 700;
-    font-size: 1.15em;
-    color: var(--color-text);
-    margin-left: 4px;
-    vertical-align: baseline;
+#time-left {
+    transition: color 0.3s ease;
 }
 #time-left.low-time {
   color: var(--color-error);


### PR DESCRIPTION
- Use same grid template as options-group (repeat(2, 300px))
- Timer aligned to left edge, Score to right edge
- Lives centered absolutely between them
- Mobile: same 2-column proportional layout