### PR TITLE
Add synchronous n8n webhook response for social media confirmation

### DIFF
--- a/upload.html
+++ b/upload.html
@@ -253,6 +253,16 @@
             padding: calc(var(--spacing-unit) * 4);
             color: var(--color-info-text);
         }
+
+        .social-success {
+            color: var(--color-success);
+            font-weight: 600;
+        }
+
+        .social-warning {
+            color: var(--color-info-text);
+            font-style: italic;
+        }
     </style>
 
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-4Y0MJKGDZS"></script>


### PR DESCRIPTION
- Wait for n8n webhook response instead of fire-and-forget
- Display social media post scheduling status in success message
- Add styles for social success/warning messages