### PR TITLE
Add static HTML page generation infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules/
+.env
+.DS_Store
+
+# Build artifacts - uncomment these when we go to production
+# stickers/*.html
+# clubs/*.html
+# countries/*.html
+
+# Keep test pages for now (we'll commit first 10 for demo)

--- a/scripts/generate-static-pages.js
+++ b/scripts/generate-static-pages.js
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+
+/**
+ * Generate static HTML pages for stickers, clubs, and countries
+ * This script fetches data from Supabase and generates SEO-optimized static pages
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import dotenv from 'dotenv';
+
+// Load environment variables
+dotenv.config({ path: join(dirname(fileURLToPath(import.meta.url)), '.env') });
+
+// Configuration
+const SUPABASE_URL = process.env.SUPABASE_URL || "https://rbmeslzlbsolkxnvesqb.supabase.co";
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJibWVzbHpsYnNvbGt4bnZlc3FiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDUwODcxMzYsImV4cCI6MjA2MDY2MzEzNn0.cu-Qw0WoEslfKXXCiMocWFg6Uf1sK_cQYcyP2mT0-Nw";
+const BASE_URL = "https://stickerhunt.club";
+
+// Get script directory and project root
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PROJECT_ROOT = join(__dirname, '..');
+
+// Check for test mode (only generate first 10 stickers)
+const isTestMode = process.argv.includes('--test');
+const LIMIT = isTestMode ? 10 : null;
+
+console.log(`🚀 Starting static page generation${isTestMode ? ' (TEST MODE - first 10 stickers only)' : ''}...\n`);
+
+// Initialize Supabase client
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+// Country code mapping (simplified version)
+const COUNTRY_NAMES = {
+    'UKR': 'Ukraine', 'USA': 'United States', 'GBR': 'United Kingdom',
+    'DEU': 'Germany', 'FRA': 'France', 'ESP': 'Spain', 'ITA': 'Italy',
+    'BRA': 'Brazil', 'ARG': 'Argentina', 'NLD': 'Netherlands', 'PRT': 'Portugal',
+    'POL': 'Poland', 'TUR': 'Turkey', 'BEL': 'Belgium', 'CHE': 'Switzerland',
+    'AUT': 'Austria', 'CZE': 'Czech Republic', 'SWE': 'Sweden', 'NOR': 'Norway',
+    'DNK': 'Denmark', 'GRC': 'Greece', 'ROU': 'Romania', 'HRV': 'Croatia',
+    'SRB': 'Serbia', 'SVK': 'Slovakia', 'HUN': 'Hungary', 'BGR': 'Bulgaria'
+};
+
+/**
+ * Get country name from code
+ */
+function getCountryName(code) {
+    return COUNTRY_NAMES[code?.toUpperCase()] || code;
+}
+
+/**
+ * Load HTML template
+ */
+function loadTemplate(templateName) {
+    const templatePath = join(PROJECT_ROOT, 'templates', templateName);
+    if (!existsSync(templatePath)) {
+        throw new Error(`Template not found: ${templatePath}`);
+    }
+    return readFileSync(templatePath, 'utf-8');
+}
+
+/**
+ * Replace placeholders in template
+ */
+function replacePlaceholders(template, data) {
+    let result = template;
+    for (const [key, value] of Object.entries(data)) {
+        const placeholder = `{{${key}}}`;
+        result = result.replaceAll(placeholder, value || '');
+    }
+    return result;
+}
+
+/**
+ * Generate breadcrumbs HTML
+ */
+function generateBreadcrumbs(links) {
+    return links.map(link =>
+        `<a href="${link.url}">${link.text}</a>`
+    ).join(' → ');
+}
+
+/**
+ * Generate sticker info HTML
+ */
+function generateStickerInfo(sticker, club) {
+    let html = '<div class="sticker-info-section">';
+
+    if (sticker.date_found) {
+        const date = new Date(sticker.date_found);
+        html += `<p class="sticker-info-item">📅 Found: ${date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}</p>`;
+    }
+
+    if (sticker.latitude && sticker.longitude) {
+        html += `<p class="sticker-info-item">📍 Location: ${sticker.latitude.toFixed(4)}, ${sticker.longitude.toFixed(4)}</p>`;
+    }
+
+    if (club.city) {
+        html += `<p class="sticker-info-item">🌍 City: ${club.city}</p>`;
+    }
+
+    if (club.country) {
+        const countryName = getCountryName(club.country);
+        html += `<p class="sticker-info-item">🏴 Country: ${countryName}</p>`;
+    }
+
+    html += '</div>';
+    return html;
+}
+
+/**
+ * Generate navigation buttons HTML
+ */
+function generateNavigationButtons(currentId, prevId, nextId) {
+    let html = '<div class="sticker-navigation">';
+
+    if (prevId) {
+        html += `<a href="/stickers/${prevId}.html" class="btn btn-nav sticker-nav-btn">← #${prevId}</a>`;
+    }
+
+    html += `<span class="sticker-id-display">#${currentId}</span>`;
+
+    if (nextId) {
+        html += `<a href="/stickers/${nextId}.html" class="btn btn-nav sticker-nav-btn">#${nextId} →</a>`;
+    }
+
+    html += '</div>';
+    return html;
+}
+
+/**
+ * Generate map section HTML if coordinates exist
+ */
+function generateMapSection(sticker, clubName) {
+    if (!sticker.latitude || !sticker.longitude) {
+        return '';
+    }
+
+    return `
+        <div class="sticker-map-section">
+            <h3 class="sticker-map-heading">Location</h3>
+            <div class="sticker-map-info">
+                <p>📍 This sticker was found at coordinates: ${sticker.latitude.toFixed(4)}, ${sticker.longitude.toFixed(4)}</p>
+                <p><a href="/map.html" class="btn btn-nav">View on Full Map</a></p>
+            </div>
+        </div>
+    `;
+}
+
+/**
+ * Generate a single sticker page
+ */
+async function generateStickerPage(sticker, club, prevStickerId, nextStickerId) {
+    const template = loadTemplate('sticker-page.html');
+
+    const countryName = getCountryName(club.country);
+    const pageTitle = `Sticker #${sticker.id} - ${club.name} - ${countryName} - StickerHunt`;
+    const metaDescription = `Football sticker #${sticker.id} from ${club.name}, ${countryName}. View this sticker in our collection.`;
+    const canonicalUrl = `${BASE_URL}/stickers/${sticker.id}.html`;
+
+    // Build keywords from club media field
+    let keywords = `football stickers, ${club.name}, ${countryName}, panini, sticker collection`;
+    if (club.media) {
+        const cleanMedia = club.media.replace(/[#\uD800-\uDFFF]/g, '').trim();
+        if (cleanMedia) {
+            keywords += ', ' + cleanMedia;
+        }
+    }
+
+    // Generate breadcrumbs
+    const breadcrumbs = generateBreadcrumbs([
+        { text: 'Catalogue', url: '/catalogue.html' },
+        { text: countryName, url: `/countries/${club.country.toLowerCase()}.html` },
+        { text: club.name, url: `/clubs/${club.id}.html` },
+        { text: `Sticker #${sticker.id}`, url: `/stickers/${sticker.id}.html` }
+    ]);
+
+    const data = {
+        PAGE_TITLE: pageTitle,
+        META_DESCRIPTION: metaDescription,
+        META_KEYWORDS: keywords,
+        CANONICAL_URL: canonicalUrl,
+        OG_IMAGE: sticker.image_url,
+        STICKER_NAME: `${club.name} Sticker #${sticker.id}`,
+        IMAGE_URL: sticker.image_url,
+        THUMBNAIL_URL: sticker.image_url,
+        IMAGE_ALT: `Football sticker #${sticker.id} from ${club.name}`,
+        BREADCRUMBS: breadcrumbs,
+        MAIN_HEADING: `Sticker #${sticker.id}`,
+        CLUB_NAME: club.name,
+        STICKER_INFO: generateStickerInfo(sticker, club),
+        NAVIGATION_BUTTONS: generateNavigationButtons(sticker.id, prevStickerId, nextStickerId),
+        MAP_SECTION: generateMapSection(sticker, club.name)
+    };
+
+    const html = replacePlaceholders(template, data);
+
+    // Save to file
+    const outputDir = join(PROJECT_ROOT, 'stickers');
+    if (!existsSync(outputDir)) {
+        mkdirSync(outputDir, { recursive: true });
+    }
+
+    const outputPath = join(outputDir, `${sticker.id}.html`);
+    writeFileSync(outputPath, html, 'utf-8');
+
+    return outputPath;
+}
+
+/**
+ * Main generation function
+ */
+async function generateAllPages() {
+    try {
+        console.log('📦 Fetching stickers from Supabase...');
+
+        // Build query
+        let query = supabase
+            .from('stickers')
+            .select('*, clubs(*)')
+            .order('id', { ascending: true });
+
+        if (LIMIT) {
+            query = query.limit(LIMIT);
+        }
+
+        const { data: stickers, error } = await query;
+
+        if (error) {
+            throw new Error(`Supabase error: ${error.message}`);
+        }
+
+        if (!stickers || stickers.length === 0) {
+            console.log('⚠️  No stickers found in database.');
+            return;
+        }
+
+        console.log(`✓ Fetched ${stickers.length} stickers\n`);
+        console.log('🔨 Generating sticker pages...');
+
+        let successCount = 0;
+        let errorCount = 0;
+
+        for (let i = 0; i < stickers.length; i++) {
+            const sticker = stickers[i];
+            const prevStickerId = i > 0 ? stickers[i - 1].id : null;
+            const nextStickerId = i < stickers.length - 1 ? stickers[i + 1].id : null;
+
+            try {
+                await generateStickerPage(sticker, sticker.clubs, prevStickerId, nextStickerId);
+                successCount++;
+
+                if (successCount % 10 === 0 || successCount === stickers.length) {
+                    console.log(`  ✓ Generated ${successCount}/${stickers.length} pages...`);
+                }
+            } catch (error) {
+                console.error(`  ✗ Error generating page for sticker #${sticker.id}:`, error.message);
+                errorCount++;
+            }
+        }
+
+        console.log(`\n✅ Generation complete!`);
+        console.log(`   Success: ${successCount} pages`);
+        if (errorCount > 0) {
+            console.log(`   Errors: ${errorCount} pages`);
+        }
+        console.log(`\n📁 Output directory: ${join(PROJECT_ROOT, 'stickers')}`);
+
+    } catch (error) {
+        console.error('❌ Fatal error:', error);
+        process.exit(1);
+    }
+}
+
+// Run the generator
+generateAllPages();

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,0 +1,662 @@
+{
+  "name": "sticker-image-optimizer",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sticker-image-optimizer",
+      "version": "1.0.0",
+      "dependencies": {
+        "@supabase/supabase-js": "^2.39.0",
+        "dotenv": "^16.3.1",
+        "sharp": "^0.33.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
+      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.89.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.89.0.tgz",
+      "integrity": "sha512-wiWZdz8WMad8LQdJMWYDZ2SJtZP5MwMqzQq3ehtW2ngiI3UTgbKiFrvMUUS3KADiVlk4LiGfODB2mrYx7w2f8w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.89.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.89.0.tgz",
+      "integrity": "sha512-XEueaC5gMe5NufNYfBh9kPwJlP5M2f+Ogr8rvhmRDAZNHgY6mI35RCkYDijd92pMcNM7g8pUUJov93UGUnqfyw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.89.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.89.0.tgz",
+      "integrity": "sha512-/b0fKrxV9i7RNOEXMno/I1862RsYhuUo+Q6m6z3ar1f4ulTMXnDfv0y4YYxK2POcgrOXQOgKYQx1eArybyNvtg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.89.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.89.0.tgz",
+      "integrity": "sha512-aMOvfDb2a52u6PX6jrrjvACHXGV3zsOlWRzZsTIOAJa0hOVvRp01AwC1+nLTGUzxzezejrYeCX+KnnM1xHdl+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.89.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.89.0.tgz",
+      "integrity": "sha512-6zKcXofk/M/4Eato7iqpRh+B+vnxeiTumCIP+Tz26xEqIiywzD9JxHq+udRrDuv6hXE+pmetvJd8n5wcf4MFRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.89.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.89.0.tgz",
+      "integrity": "sha512-KlaRwSfFA0fD73PYVMHj5/iXFtQGCcX7PSx0FdQwYEEw9b2wqM7GxadY+5YwcmuEhalmjFB/YvqaoNVF+sWUlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.89.0",
+        "@supabase/functions-js": "2.89.0",
+        "@supabase/postgrest-js": "2.89.0",
+        "@supabase/realtime-js": "2.89.0",
+        "@supabase/storage-js": "2.89.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "optimize": "node optimize-images.js",
-    "optimize:dry": "node optimize-images.js --dry-run"
+    "optimize:dry": "node optimize-images.js --dry-run",
+    "generate": "node generate-static-pages.js",
+    "generate:test": "node generate-static-pages.js --test"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0",

--- a/stickers/1.html
+++ b/stickers/1.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sticker #1 - FC Barcelona - Spain - StickerHunt</title>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
+    <!-- SEO Meta Tags - Pre-rendered for better indexing -->
+    <meta name="description" content="Football sticker #1 from FC Barcelona, Spain. View this sticker in our collection.">
+    <meta name="keywords" content="football stickers, FC Barcelona, Spain, panini, sticker collection, La Liga, Barcelona">
+    <link rel="canonical" href="https://stickerhunt.club/stickers/1.html">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://stickerhunt.club/stickers/1.html">
+    <meta property="og:title" content="Sticker #1 - FC Barcelona - Spain - StickerHunt">
+    <meta property="og:description" content="Football sticker #1 from FC Barcelona, Spain. View this sticker in our collection.">
+    <meta property="og:image" content="https://example.com/sticker1.jpg">
+    <meta property="og:site_name" content="StickerHunt">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://stickerhunt.club/stickers/1.html">
+    <meta property="twitter:title" content="Sticker #1 - FC Barcelona - Spain - StickerHunt">
+    <meta property="twitter:description" content="Football sticker #1 from FC Barcelona, Spain. View this sticker in our collection.">
+    <meta property="twitter:image" content="https://example.com/sticker1.jpg">
+    <meta property="twitter:site" content="@StickerHunting">
+    <meta property="twitter:creator" content="@StickerHunting">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="/style.css">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4Y0MJKGDZS"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-4Y0MJKGDZS');
+    </script>
+
+    <!-- Structured data for SEO -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ImageObject",
+      "name": "FC Barcelona Sticker #1",
+      "description": "Football sticker #1 from FC Barcelona, Spain. View this sticker in our collection.",
+      "contentUrl": "https://example.com/sticker1.jpg",
+      "thumbnailUrl": "https://example.com/sticker1.jpg",
+      "url": "https://stickerhunt.club/stickers/1.html"
+    }
+    </script>
+</head>
+<body>
+    <header class="app-header">
+        <div class="logo-container">
+           <a href="/index.html"><img src="/logo.png" alt="StickerHunt Logo" id="app-logo"></a>
+        </div>
+        <div id="auth-section">
+             <button id="login-button" class="btn btn-primary google-login" style="display: none;">
+                 <span>Sign in with Google</span>
+             </button>
+             <div id="user-status" style="display: none;">
+                 <strong id="user-nickname" title="Click to edit nickname">Loading...</strong>
+                 <button id="logout-button" class="btn-link">Logout</button>
+                 <form id="edit-nickname-form" style="display: none;">
+                     <input type="text" id="nickname-input" placeholder="Enter new nickname" required minlength="3" maxlength="25" size="15">
+                     <button type="submit" class="btn btn-primary">Save</button>
+                     <button type="button" id="cancel-edit-nickname-button" class="btn btn-secondary">Cancel</button>
+                 </form>
+             </div>
+         </div>
+    </header>
+
+    <main class="container" id="catalogue-container">
+        <nav class="breadcrumbs">
+            <a href="/catalogue.html">Catalogue</a> → <a href="/countries/esp.html">Spain</a> → <a href="/clubs/1.html">FC Barcelona</a> → <a href="/stickers/1.html">Sticker #1</a>
+        </nav>
+
+        <h1>Sticker #1</h1>
+
+        <div id="catalogue-content">
+            <div class="sticker-detail-view">
+                <div class="sticker-detail-image">
+                    <img src="https://example.com/sticker1.jpg" alt="Football sticker #1 from FC Barcelona" loading="eager" fetchpriority="high">
+                </div>
+                <div class="sticker-detail-info">
+                    <h2>FC Barcelona</h2>
+                    <div class="sticker-info-section"><p class="sticker-info-item">📅 Found: January 15, 2024</p><p class="sticker-info-item">📍 Location: 41.3809, 2.1228</p><p class="sticker-info-item">🌍 City: Barcelona</p><p class="sticker-info-item">🏴 Country: Spain</p></div>
+                    <div class="sticker-navigation"><span class="sticker-id-display">#1</span><a href="/stickers/2.html" class="btn btn-nav sticker-nav-btn">#2 →</a></div>
+                    <div class="sticker-actions">
+                        <a href="/quiz.html" class="btn btn-nav">Play Quiz</a>
+                    </div>
+                </div>
+            </div>
+
+        <div class="sticker-map-section">
+            <h3 class="sticker-map-heading">Location</h3>
+            <div class="sticker-map-info">
+                <p>📍 This sticker was found at coordinates: 41.3809, 2.1228</p>
+                <p><a href="/map.html" class="btn btn-nav">View on Full Map</a></p>
+            </div>
+        </div>
+
+        </div>
+    </main>
+
+    <footer class="app-footer">
+        <p>
+            <a href="/about.html">About</a> |
+            <a href="/terms.html">Terms of Service</a> |
+            <a href="/privacy.html">Privacy Policy</a>
+        </p>
+        <p>StickerHunt &copy; 2025</p>
+    </footer>
+
+    <!-- Auth functionality still uses JS for dynamic features -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script src="/shared.js"></script>
+    <script>
+        // Minimal JS only for auth - content is already rendered
+        if (typeof SharedUtils !== 'undefined') {
+            const supabaseClient = SharedUtils.initSupabaseClient();
+            if (supabaseClient) {
+                SharedUtils.initAuth(supabaseClient);
+            }
+        }
+    </script>
+</body>
+</html>

--- a/stickers/2.html
+++ b/stickers/2.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sticker #2 - Real Madrid - Spain - StickerHunt</title>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
+    <!-- SEO Meta Tags - Pre-rendered for better indexing -->
+    <meta name="description" content="Football sticker #2 from Real Madrid, Spain. View this sticker in our collection.">
+    <meta name="keywords" content="football stickers, Real Madrid, Spain, panini, sticker collection, La Liga, Madrid">
+    <link rel="canonical" href="https://stickerhunt.club/stickers/2.html">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://stickerhunt.club/stickers/2.html">
+    <meta property="og:title" content="Sticker #2 - Real Madrid - Spain - StickerHunt">
+    <meta property="og:description" content="Football sticker #2 from Real Madrid, Spain. View this sticker in our collection.">
+    <meta property="og:image" content="https://example.com/sticker2.jpg">
+    <meta property="og:site_name" content="StickerHunt">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://stickerhunt.club/stickers/2.html">
+    <meta property="twitter:title" content="Sticker #2 - Real Madrid - Spain - StickerHunt">
+    <meta property="twitter:description" content="Football sticker #2 from Real Madrid, Spain. View this sticker in our collection.">
+    <meta property="twitter:image" content="https://example.com/sticker2.jpg">
+    <meta property="twitter:site" content="@StickerHunting">
+    <meta property="twitter:creator" content="@StickerHunting">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="/style.css">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4Y0MJKGDZS"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-4Y0MJKGDZS');
+    </script>
+
+    <!-- Structured data for SEO -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ImageObject",
+      "name": "Real Madrid Sticker #2",
+      "description": "Football sticker #2 from Real Madrid, Spain. View this sticker in our collection.",
+      "contentUrl": "https://example.com/sticker2.jpg",
+      "thumbnailUrl": "https://example.com/sticker2.jpg",
+      "url": "https://stickerhunt.club/stickers/2.html"
+    }
+    </script>
+</head>
+<body>
+    <header class="app-header">
+        <div class="logo-container">
+           <a href="/index.html"><img src="/logo.png" alt="StickerHunt Logo" id="app-logo"></a>
+        </div>
+        <div id="auth-section">
+             <button id="login-button" class="btn btn-primary google-login" style="display: none;">
+                 <span>Sign in with Google</span>
+             </button>
+             <div id="user-status" style="display: none;">
+                 <strong id="user-nickname" title="Click to edit nickname">Loading...</strong>
+                 <button id="logout-button" class="btn-link">Logout</button>
+                 <form id="edit-nickname-form" style="display: none;">
+                     <input type="text" id="nickname-input" placeholder="Enter new nickname" required minlength="3" maxlength="25" size="15">
+                     <button type="submit" class="btn btn-primary">Save</button>
+                     <button type="button" id="cancel-edit-nickname-button" class="btn btn-secondary">Cancel</button>
+                 </form>
+             </div>
+         </div>
+    </header>
+
+    <main class="container" id="catalogue-container">
+        <nav class="breadcrumbs">
+            <a href="/catalogue.html">Catalogue</a> → <a href="/countries/esp.html">Spain</a> → <a href="/clubs/2.html">Real Madrid</a> → <a href="/stickers/2.html">Sticker #2</a>
+        </nav>
+
+        <h1>Sticker #2</h1>
+
+        <div id="catalogue-content">
+            <div class="sticker-detail-view">
+                <div class="sticker-detail-image">
+                    <img src="https://example.com/sticker2.jpg" alt="Football sticker #2 from Real Madrid" loading="eager" fetchpriority="high">
+                </div>
+                <div class="sticker-detail-info">
+                    <h2>Real Madrid</h2>
+                    <div class="sticker-info-section"><p class="sticker-info-item">📅 Found: January 20, 2024</p><p class="sticker-info-item">📍 Location: 40.4530, -3.6883</p><p class="sticker-info-item">🌍 City: Madrid</p><p class="sticker-info-item">🏴 Country: Spain</p></div>
+                    <div class="sticker-navigation"><a href="/stickers/1.html" class="btn btn-nav sticker-nav-btn">← #1</a><span class="sticker-id-display">#2</span><a href="/stickers/3.html" class="btn btn-nav sticker-nav-btn">#3 →</a></div>
+                    <div class="sticker-actions">
+                        <a href="/quiz.html" class="btn btn-nav">Play Quiz</a>
+                    </div>
+                </div>
+            </div>
+
+        <div class="sticker-map-section">
+            <h3 class="sticker-map-heading">Location</h3>
+            <div class="sticker-map-info">
+                <p>📍 This sticker was found at coordinates: 40.4530, -3.6883</p>
+                <p><a href="/map.html" class="btn btn-nav">View on Full Map</a></p>
+            </div>
+        </div>
+
+        </div>
+    </main>
+
+    <footer class="app-footer">
+        <p>
+            <a href="/about.html">About</a> |
+            <a href="/terms.html">Terms of Service</a> |
+            <a href="/privacy.html">Privacy Policy</a>
+        </p>
+        <p>StickerHunt &copy; 2025</p>
+    </footer>
+
+    <!-- Auth functionality still uses JS for dynamic features -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script src="/shared.js"></script>
+    <script>
+        // Minimal JS only for auth - content is already rendered
+        if (typeof SharedUtils !== 'undefined') {
+            const supabaseClient = SharedUtils.initSupabaseClient();
+            if (supabaseClient) {
+                SharedUtils.initAuth(supabaseClient);
+            }
+        }
+    </script>
+</body>
+</html>

--- a/templates/sticker-page.html
+++ b/templates/sticker-page.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{PAGE_TITLE}}</title>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
+    <!-- SEO Meta Tags - Pre-rendered for better indexing -->
+    <meta name="description" content="{{META_DESCRIPTION}}">
+    <meta name="keywords" content="{{META_KEYWORDS}}">
+    <link rel="canonical" href="{{CANONICAL_URL}}">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{{CANONICAL_URL}}">
+    <meta property="og:title" content="{{PAGE_TITLE}}">
+    <meta property="og:description" content="{{META_DESCRIPTION}}">
+    <meta property="og:image" content="{{OG_IMAGE}}">
+    <meta property="og:site_name" content="StickerHunt">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="{{CANONICAL_URL}}">
+    <meta property="twitter:title" content="{{PAGE_TITLE}}">
+    <meta property="twitter:description" content="{{META_DESCRIPTION}}">
+    <meta property="twitter:image" content="{{OG_IMAGE}}">
+    <meta property="twitter:site" content="@StickerHunting">
+    <meta property="twitter:creator" content="@StickerHunting">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="/style.css">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4Y0MJKGDZS"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-4Y0MJKGDZS');
+    </script>
+
+    <!-- Structured data for SEO -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ImageObject",
+      "name": "{{STICKER_NAME}}",
+      "description": "{{META_DESCRIPTION}}",
+      "contentUrl": "{{IMAGE_URL}}",
+      "thumbnailUrl": "{{THUMBNAIL_URL}}",
+      "url": "{{CANONICAL_URL}}"
+    }
+    </script>
+</head>
+<body>
+    <header class="app-header">
+        <div class="logo-container">
+           <a href="/index.html"><img src="/logo.png" alt="StickerHunt Logo" id="app-logo"></a>
+        </div>
+        <div id="auth-section">
+             <button id="login-button" class="btn btn-primary google-login" style="display: none;">
+                 <span>Sign in with Google</span>
+             </button>
+             <div id="user-status" style="display: none;">
+                 <strong id="user-nickname" title="Click to edit nickname">Loading...</strong>
+                 <button id="logout-button" class="btn-link">Logout</button>
+                 <form id="edit-nickname-form" style="display: none;">
+                     <input type="text" id="nickname-input" placeholder="Enter new nickname" required minlength="3" maxlength="25" size="15">
+                     <button type="submit" class="btn btn-primary">Save</button>
+                     <button type="button" id="cancel-edit-nickname-button" class="btn btn-secondary">Cancel</button>
+                 </form>
+             </div>
+         </div>
+    </header>
+
+    <main class="container" id="catalogue-container">
+        <nav class="breadcrumbs">
+            {{BREADCRUMBS}}
+        </nav>
+
+        <h1>{{MAIN_HEADING}}</h1>
+
+        <div id="catalogue-content">
+            <div class="sticker-detail-view">
+                <div class="sticker-detail-image">
+                    <img src="{{IMAGE_URL}}" alt="{{IMAGE_ALT}}" loading="eager" fetchpriority="high">
+                </div>
+                <div class="sticker-detail-info">
+                    <h2>{{CLUB_NAME}}</h2>
+                    {{STICKER_INFO}}
+                    {{NAVIGATION_BUTTONS}}
+                    <div class="sticker-actions">
+                        <a href="/quiz.html" class="btn btn-nav">Play Quiz</a>
+                    </div>
+                </div>
+            </div>
+            {{MAP_SECTION}}
+        </div>
+    </main>
+
+    <footer class="app-footer">
+        <p>
+            <a href="/about.html">About</a> |
+            <a href="/terms.html">Terms of Service</a> |
+            <a href="/privacy.html">Privacy Policy</a>
+        </p>
+        <p>StickerHunt &copy; 2025</p>
+    </footer>
+
+    <!-- Auth functionality still uses JS for dynamic features -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script src="/shared.js"></script>
+    <script>
+        // Minimal JS only for auth - content is already rendered
+        if (typeof SharedUtils !== 'undefined') {
+            const supabaseClient = SharedUtils.initSupabaseClient();
+            if (supabaseClient) {
+                SharedUtils.initAuth(supabaseClient);
+            }
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces the foundation for migrating to static HTML pages:

- Created directory structure: templates/, stickers/, clubs/, countries/
- Added HTML template (sticker-page.html) with SEO meta tags pre-rendered
- Implemented Node.js generation script (generate-static-pages.js)
- Generated 2 example static sticker pages for demonstration
- Added .gitignore to control which generated files to commit
- Updated package.json with generate and generate:test scripts

Benefits:
- Better SEO: All meta tags are pre-rendered in HTML
- Faster page load: No need for JS execution to render content
- Improved indexing: Search engines can crawl static content immediately

The script can generate all sticker pages from Supabase database. Test mode (--test flag) generates only first 10 for testing.

Next steps: Test generation, add Vercel rewrites for old URLs