### PR TITLE
Update .gitignore and documentation for production readiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,13 @@ node_modules/
 .env
 .DS_Store
 
-# Build artifacts - uncomment these when we go to production
-# stickers/*.html
-# clubs/*.html
-# countries/*.html
+# Generated static pages (exclude from git)
+stickers/*.html
+clubs/*.html
+countries/*.html
 
-# Keep test pages for now (we'll commit first 10 for demo)
+# Keep a few examples for demonstration
+!stickers/4.html
+!stickers/5.html
+!clubs/27.html
+!countries/ukr.html

--- a/STATIC-PAGES.md
+++ b/STATIC-PAGES.md
@@ -32,20 +32,22 @@ This project uses a hybrid approach for rendering pages:
 ```
 football-sticker-quiz/
 ├── templates/              # HTML templates with placeholders
-│   ├── sticker-page.html
-│   ├── club-page.html      # TODO: Next session
-│   └── country-page.html   # TODO: Next session
+│   ├── sticker-page.html  ✅ Complete
+│   ├── club-page.html     ✅ Complete
+│   └── country-page.html  ✅ Complete
 │
 ├── stickers/               # Generated static sticker pages
-│   ├── 1.html
-│   ├── 2.html
-│   └── ... (thousands more)
+│   ├── 4.html             # Only existing stickers (gaps in IDs are normal)
+│   ├── 5.html
+│   └── ... (~2800 files)
 │
 ├── clubs/                  # Generated static club pages
-│   └── ... (to be generated)
+│   ├── 27.html
+│   └── ... (654 clubs)
 │
 ├── countries/              # Generated static country pages
-│   └── ... (to be generated)
+│   ├── ukr.html
+│   └── ... (54 countries)
 │
 └── scripts/
     └── generate-static-pages.js  # Generation script


### PR DESCRIPTION
- Updated .gitignore to exclude generated HTML files from git
- Keep only a few example pages for demonstration (4.html, 5.html, etc)
- Updated STATIC-PAGES.md to reflect completed club and country templates
- Added note about ID gaps being normal (deleted stickers)

All three page types are now complete:
- Stickers: ~2800 pages
- Clubs: 654 pages
- Countries: 54 pages

Ready for production deployment.