### PR TITLE
Fix View Sticker Info button to properly link to failed sticker

### DIFF
--- a/script.js
+++ b/script.js
@@ -750,7 +750,7 @@ async function handleAnswer(selectedOption) {
             if (correctButton) correctButton.classList.add('correct-answer');
 
             // Track the last failed sticker for the end game screen
-            if (currentQuestionData && currentQuestionData.stickerId) {
+            if (currentQuestionData && currentQuestionData.stickerId != null) {
                 lastFailedStickerId = currentQuestionData.stickerId;
             }
 
@@ -805,7 +805,7 @@ async function handleAnswerTTR(isCorrect, selectedButton, correctButton) {
         if (correctButton) correctButton.classList.add('correct-answer');
 
         // Track the last failed sticker for the end game screen
-        if (currentQuestionData && currentQuestionData.stickerId) {
+        if (currentQuestionData && currentQuestionData.stickerId != null) {
             lastFailedStickerId = currentQuestionData.stickerId;
         }
     }
@@ -946,7 +946,7 @@ function startTimer() {
                 });
 
                 // Track current sticker as failed when timer runs out
-                if (currentQuestionData.stickerId) {
+                if (currentQuestionData.stickerId != null) {
                     lastFailedStickerId = currentQuestionData.stickerId;
                 }
             }
@@ -1557,7 +1557,7 @@ function endGame() {
     if (introTextElement) introTextElement.style.display = 'none';
 
     // Update sticker info button to link to the last failed sticker
-    if (resultStickerInfoButton && lastFailedStickerId) {
+    if (resultStickerInfoButton && lastFailedStickerId != null) {
         resultStickerInfoButton.href = `/stickers/${lastFailedStickerId}.html`;
     } else if (resultStickerInfoButton) {
         resultStickerInfoButton.href = '/catalogue.html';


### PR DESCRIPTION
Changed stickerId and lastFailedStickerId checks from truthy to explicit null checks (!=  null) to handle cases where stickerId could be 0.

Fixes:
- Classic mode wrong answer tracking
- TTR mode wrong answer tracking
- Timer timeout tracking
- endGame() button href update