### PR TITLE
Fix View Sticker Info button to properly link to failed sticker

### DIFF
--- a/script.js
+++ b/script.js
@@ -750,7 +750,7 @@ async function handleAnswer(selectedOption) {
             if (correctButton) correctButton.classList.add('correct-answer');
 
             // Track the last failed sticker for the end game screen
-            if (currentQuestionData && currentQuestionData.stickerId) {
+            if (currentQuestionData && currentQuestionData.stickerId != null) {
                 lastFailedStickerId = currentQuestionData.stickerId;
             }
 
@@ -805,7 +805,7 @@ async function handleAnswerTTR(isCorrect, selectedButton, correctButton) {
         if (correctButton) correctButton.classList.add('correct-answer');
 
         // Track the last failed sticker for the end game screen
-        if (currentQuestionData && currentQuestionData.stickerId) {
+        if (currentQuestionData && currentQuestionData.stickerId != null) {
             lastFailedStickerId = currentQuestionData.stickerId;
         }
     }
@@ -946,7 +946,7 @@ function startTimer() {
                 });
 
                 // Track current sticker as failed when timer runs out
-                if (currentQuestionData.stickerId) {
+                if (currentQuestionData.stickerId != null) {
                     lastFailedStickerId = currentQuestionData.stickerId;
                 }
             }
@@ -1188,7 +1188,7 @@ async function loadNewQuestionInternal() {
 
         const { data: randomStickerData, error: stickerError } = await supabaseClient
             .from('stickers')
-            .select(`image_url, clubs ( id, name )`)
+            .select(`id, image_url, clubs ( id, name )`)
             .eq('difficulty', selectedDifficulty)
             .order('id', { ascending: true })
             .range(randomIndex, randomIndex)
@@ -1342,7 +1342,7 @@ async function loadNewQuestionInternalWithDifficulty(difficulty) {
 
         const { data: randomStickerData, error: stickerError } = await supabaseClient
             .from('stickers')
-            .select(`image_url, clubs ( id, name )`)
+            .select(`id, image_url, clubs ( id, name )`)
             .eq('difficulty', difficulty)
             .order('id', { ascending: true })
             .range(randomIndex, randomIndex)
@@ -1557,7 +1557,7 @@ function endGame() {
     if (introTextElement) introTextElement.style.display = 'none';
 
     // Update sticker info button to link to the last failed sticker
-    if (resultStickerInfoButton && lastFailedStickerId) {
+    if (resultStickerInfoButton && lastFailedStickerId != null) {
         resultStickerInfoButton.href = `/stickers/${lastFailedStickerId}.html`;
     } else if (resultStickerInfoButton) {
         resultStickerInfoButton.href = '/catalogue.html';


### PR DESCRIPTION
Root cause: The Supabase queries were not selecting the sticker 'id' field, so randomStickerData.id was always undefined, and lastFailedStickerId was never set properly.

Fixes:
- Add 'id' to select() in loadNewQuestionInternal (classic mode)
- Add 'id' to select() in loadNewQuestionInternalWithDifficulty (TTR mode)
- Use explicit null checks (!= null) for stickerId to handle edge cases