### PR TITLE
Add Amplitude analytics to all pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -107,6 +107,10 @@
             .about-photo-figure figcaption { font-size: 0.85em; }
         }
     </style>
+    <!-- Amplitude Analytics -->
+    <script src="https://cdn.amplitude.com/script/678e88d5fa8972f1fe39b2cd59ef456.js"></script>
+    <script>window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));window.amplitude.init('678e88d5fa8972f1fe39b2cd59ef456', {"fetchRemoteConfig":true,"autocapture":{"attribution":true,"fileDownloads":true,"formInteractions":true,"pageViews":true,"sessions":true,"elementInteractions":true,"networkTracking":true,"webVitals":true,"frustrationInteractions":true}});</script>
+
 </head>
 <body>
     <div class="legal-container">

--- a/catalogue.html
+++ b/catalogue.html
@@ -43,6 +43,10 @@
       gtag('js', new Date());
       gtag('config', 'G-4Y0MJKGDZS');
     </script>
+    <!-- Amplitude Analytics -->
+    <script src="https://cdn.amplitude.com/script/678e88d5fa8972f1fe39b2cd59ef456.js"></script>
+    <script>window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));window.amplitude.init('678e88d5fa8972f1fe39b2cd59ef456', {"fetchRemoteConfig":true,"autocapture":{"attribution":true,"fileDownloads":true,"formInteractions":true,"pageViews":true,"sessions":true,"elementInteractions":true,"networkTracking":true,"webVitals":true,"frustrationInteractions":true}});</script>
+
 </head>
 <body>
     <header class="app-header">

--- a/index.html
+++ b/index.html
@@ -66,6 +66,10 @@
       }
     }
     </script>
+    <!-- Amplitude Analytics -->
+    <script src="https://cdn.amplitude.com/script/678e88d5fa8972f1fe39b2cd59ef456.js"></script>
+    <script>window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));window.amplitude.init('678e88d5fa8972f1fe39b2cd59ef456', {"fetchRemoteConfig":true,"autocapture":{"attribution":true,"fileDownloads":true,"formInteractions":true,"pageViews":true,"sessions":true,"elementInteractions":true,"networkTracking":true,"webVitals":true,"frustrationInteractions":true}});</script>
+
 </head>
 <body class="home-page">
     <header class="app-header">

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -40,6 +40,10 @@
       gtag('js', new Date());
       gtag('config', 'G-4Y0MJKGDZS');
     </script>
+    <!-- Amplitude Analytics -->
+    <script src="https://cdn.amplitude.com/script/678e88d5fa8972f1fe39b2cd59ef456.js"></script>
+    <script>window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));window.amplitude.init('678e88d5fa8972f1fe39b2cd59ef456', {"fetchRemoteConfig":true,"autocapture":{"attribution":true,"fileDownloads":true,"formInteractions":true,"pageViews":true,"sessions":true,"elementInteractions":true,"networkTracking":true,"webVitals":true,"frustrationInteractions":true}});</script>
+
 </head>
 <body>
     <header class="app-header">

--- a/map.html
+++ b/map.html
@@ -43,6 +43,10 @@
       gtag('js', new Date());
       gtag('config', 'G-4Y0MJKGDZS');
     </script>
+    <!-- Amplitude Analytics -->
+    <script src="https://cdn.amplitude.com/script/678e88d5fa8972f1fe39b2cd59ef456.js"></script>
+    <script>window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));window.amplitude.init('678e88d5fa8972f1fe39b2cd59ef456', {"fetchRemoteConfig":true,"autocapture":{"attribution":true,"fileDownloads":true,"formInteractions":true,"pageViews":true,"sessions":true,"elementInteractions":true,"networkTracking":true,"webVitals":true,"frustrationInteractions":true}});</script>
+
 </head>
 <body>
     <header class="app-header">

--- a/privacy.html
+++ b/privacy.html
@@ -22,6 +22,10 @@
         .legal-container a { color: var(--color-link); }
         .back-link { display: block; text-align: center; margin-top: 30px; }
     </style>
+    <!-- Amplitude Analytics -->
+    <script src="https://cdn.amplitude.com/script/678e88d5fa8972f1fe39b2cd59ef456.js"></script>
+    <script>window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));window.amplitude.init('678e88d5fa8972f1fe39b2cd59ef456', {"fetchRemoteConfig":true,"autocapture":{"attribution":true,"fileDownloads":true,"formInteractions":true,"pageViews":true,"sessions":true,"elementInteractions":true,"networkTracking":true,"webVitals":true,"frustrationInteractions":true}});</script>
+
 </head>
 <body>
     <div class="legal-container">

--- a/profile.html
+++ b/profile.html
@@ -40,6 +40,10 @@
       gtag('js', new Date());
       gtag('config', 'G-4Y0MJKGDZS');
     </script>
+    <!-- Amplitude Analytics -->
+    <script src="https://cdn.amplitude.com/script/678e88d5fa8972f1fe39b2cd59ef456.js"></script>
+    <script>window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));window.amplitude.init('678e88d5fa8972f1fe39b2cd59ef456', {"fetchRemoteConfig":true,"autocapture":{"attribution":true,"fileDownloads":true,"formInteractions":true,"pageViews":true,"sessions":true,"elementInteractions":true,"networkTracking":true,"webVitals":true,"frustrationInteractions":true}});</script>
+
 </head>
 <body>
     <header class="app-header">

--- a/quiz.html
+++ b/quiz.html
@@ -40,6 +40,10 @@
       gtag('js', new Date());
       gtag('config', 'G-4Y0MJKGDZS');
     </script>
+    <!-- Amplitude Analytics -->
+    <script src="https://cdn.amplitude.com/script/678e88d5fa8972f1fe39b2cd59ef456.js"></script>
+    <script>window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));window.amplitude.init('678e88d5fa8972f1fe39b2cd59ef456', {"fetchRemoteConfig":true,"autocapture":{"attribution":true,"fileDownloads":true,"formInteractions":true,"pageViews":true,"sessions":true,"elementInteractions":true,"networkTracking":true,"webVitals":true,"frustrationInteractions":true}});</script>
+
 </head>
 <body>
     <header class="app-header">

--- a/stickerlog.html
+++ b/stickerlog.html
@@ -40,6 +40,10 @@
       gtag('js', new Date());
       gtag('config', 'G-4Y0MJKGDZS');
     </script>
+    <!-- Amplitude Analytics -->
+    <script src="https://cdn.amplitude.com/script/678e88d5fa8972f1fe39b2cd59ef456.js"></script>
+    <script>window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));window.amplitude.init('678e88d5fa8972f1fe39b2cd59ef456', {"fetchRemoteConfig":true,"autocapture":{"attribution":true,"fileDownloads":true,"formInteractions":true,"pageViews":true,"sessions":true,"elementInteractions":true,"networkTracking":true,"webVitals":true,"frustrationInteractions":true}});</script>
+
 </head>
 <body>
     <header class="app-header">

--- a/stickerstat.html
+++ b/stickerstat.html
@@ -40,6 +40,10 @@
       gtag('js', new Date());
       gtag('config', 'G-4Y0MJKGDZS');
     </script>
+    <!-- Amplitude Analytics -->
+    <script src="https://cdn.amplitude.com/script/678e88d5fa8972f1fe39b2cd59ef456.js"></script>
+    <script>window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));window.amplitude.init('678e88d5fa8972f1fe39b2cd59ef456', {"fetchRemoteConfig":true,"autocapture":{"attribution":true,"fileDownloads":true,"formInteractions":true,"pageViews":true,"sessions":true,"elementInteractions":true,"networkTracking":true,"webVitals":true,"frustrationInteractions":true}});</script>
+
 </head>
 <body>
     <header class="app-header">

--- a/templates/club-page.html
+++ b/templates/club-page.html
@@ -56,6 +56,10 @@
       "sport": "Football"
     }
     </script>
+    <!-- Amplitude Analytics -->
+    <script src="https://cdn.amplitude.com/script/678e88d5fa8972f1fe39b2cd59ef456.js"></script>
+    <script>window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));window.amplitude.init('678e88d5fa8972f1fe39b2cd59ef456', {"fetchRemoteConfig":true,"autocapture":{"attribution":true,"fileDownloads":true,"formInteractions":true,"pageViews":true,"sessions":true,"elementInteractions":true,"networkTracking":true,"webVitals":true,"frustrationInteractions":true}});</script>
+
 </head>
 <body>
     <header class="app-header">

--- a/templates/country-page.html
+++ b/templates/country-page.html
@@ -53,6 +53,10 @@
       "numberOfItems": {{CLUB_COUNT}}
     }
     </script>
+    <!-- Amplitude Analytics -->
+    <script src="https://cdn.amplitude.com/script/678e88d5fa8972f1fe39b2cd59ef456.js"></script>
+    <script>window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));window.amplitude.init('678e88d5fa8972f1fe39b2cd59ef456', {"fetchRemoteConfig":true,"autocapture":{"attribution":true,"fileDownloads":true,"formInteractions":true,"pageViews":true,"sessions":true,"elementInteractions":true,"networkTracking":true,"webVitals":true,"frustrationInteractions":true}});</script>
+
 </head>
 <body>
     <header class="app-header">

--- a/templates/index-page.html
+++ b/templates/index-page.html
@@ -66,6 +66,10 @@
       }
     }
     </script>
+    <!-- Amplitude Analytics -->
+    <script src="https://cdn.amplitude.com/script/678e88d5fa8972f1fe39b2cd59ef456.js"></script>
+    <script>window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));window.amplitude.init('678e88d5fa8972f1fe39b2cd59ef456', {"fetchRemoteConfig":true,"autocapture":{"attribution":true,"fileDownloads":true,"formInteractions":true,"pageViews":true,"sessions":true,"elementInteractions":true,"networkTracking":true,"webVitals":true,"frustrationInteractions":true}});</script>
+
 </head>
 <body class="home-page">
     <header class="app-header">

--- a/templates/sticker-page.html
+++ b/templates/sticker-page.html
@@ -57,6 +57,10 @@
       "url": "{{CANONICAL_URL}}"
     }
     </script>
+    <!-- Amplitude Analytics -->
+    <script src="https://cdn.amplitude.com/script/678e88d5fa8972f1fe39b2cd59ef456.js"></script>
+    <script>window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));window.amplitude.init('678e88d5fa8972f1fe39b2cd59ef456', {"fetchRemoteConfig":true,"autocapture":{"attribution":true,"fileDownloads":true,"formInteractions":true,"pageViews":true,"sessions":true,"elementInteractions":true,"networkTracking":true,"webVitals":true,"frustrationInteractions":true}});</script>
+
 </head>
 <body>
     <header class="app-header">

--- a/terms.html
+++ b/terms.html
@@ -22,6 +22,10 @@
         .legal-container a { color: var(--color-link); }
         .back-link { display: block; text-align: center; margin-top: 30px; }
     </style>
+    <!-- Amplitude Analytics -->
+    <script src="https://cdn.amplitude.com/script/678e88d5fa8972f1fe39b2cd59ef456.js"></script>
+    <script>window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));window.amplitude.init('678e88d5fa8972f1fe39b2cd59ef456', {"fetchRemoteConfig":true,"autocapture":{"attribution":true,"fileDownloads":true,"formInteractions":true,"pageViews":true,"sessions":true,"elementInteractions":true,"networkTracking":true,"webVitals":true,"frustrationInteractions":true}});</script>
+
 </head>
 <body>
     <div class="legal-container">

--- a/upload.html
+++ b/upload.html
@@ -272,6 +272,10 @@
       gtag('js', new Date());
       gtag('config', 'G-4Y0MJKGDZS');
     </script>
+    <!-- Amplitude Analytics -->
+    <script src="https://cdn.amplitude.com/script/678e88d5fa8972f1fe39b2cd59ef456.js"></script>
+    <script>window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));window.amplitude.init('678e88d5fa8972f1fe39b2cd59ef456', {"fetchRemoteConfig":true,"autocapture":{"attribution":true,"fileDownloads":true,"formInteractions":true,"pageViews":true,"sessions":true,"elementInteractions":true,"networkTracking":true,"webVitals":true,"frustrationInteractions":true}});</script>
+
 </head>
 <body>
     <header class="app-header">


### PR DESCRIPTION
Added Amplitude analytics script to:
- All main HTML pages (12 files)
- All page templates (4 files)

This enables comprehensive user behavior tracking including:
- Page views and sessions
- User interactions and form submissions
- File downloads and network activity
- Web vitals and frustration tracking
- Session replay for better UX insights