### PR TITLE
Integrate Amplitude user identification

### DIFF
--- a/script.js
+++ b/script.js
@@ -419,6 +419,7 @@ function setupAuthStateListener() {
             }
             currentUser = null;
             currentUserProfile = null;
+            SharedUtils.clearAmplitudeUser(); // Clear Amplitude user ID
             updateAuthStateUI(null);
             return;
         }
@@ -434,6 +435,7 @@ function setupAuthStateListener() {
                     currentUserProfile = cachedProfile;
                 }
                 checkAndCreateUserProfile(user).then(() => {
+                    SharedUtils.identifyAmplitudeUser(user, currentUserProfile); // Identify user in Amplitude
                     updateAuthStateUI(user);
                 });
             }
@@ -1853,6 +1855,7 @@ function initializeApp() {
 
             // Fetch fresh profile in background and update UI again
             checkAndCreateUserProfile(user).then(() => {
+                SharedUtils.identifyAmplitudeUser(user, currentUserProfile); // Identify user in Amplitude
                 updateAuthStateUI(user);
             }).catch(err => {
                 console.error("Profile load error:", err);

--- a/shared.js
+++ b/shared.js
@@ -127,6 +127,61 @@ function generateRandomNickname() {
 }
 
 // ============================================================
+// AMPLITUDE ANALYTICS INTEGRATION
+// ============================================================
+
+/**
+ * Identify user in Amplitude when they sign in
+ * @param {Object} user - Supabase user object
+ * @param {Object} profile - User profile with nickname
+ */
+function identifyAmplitudeUser(user, profile = null) {
+    if (typeof window.amplitude === 'undefined') {
+        console.warn('Amplitude not loaded, skipping user identification');
+        return;
+    }
+
+    try {
+        // Set user ID (Supabase user ID)
+        window.amplitude.setUserId(user.id);
+
+        // Set user properties for better analytics
+        const userProperties = {
+            email: user.email,
+            provider: user.app_metadata?.provider || 'unknown',
+            created_at: user.created_at
+        };
+
+        // Add nickname if available
+        if (profile && profile.nickname) {
+            userProperties.nickname = profile.nickname;
+        }
+
+        window.amplitude.identify(new window.amplitude.Identify().set(userProperties));
+        console.log('Amplitude: User identified', user.id);
+    } catch (error) {
+        console.error('Error identifying user in Amplitude:', error);
+    }
+}
+
+/**
+ * Clear user identification in Amplitude when they sign out
+ */
+function clearAmplitudeUser() {
+    if (typeof window.amplitude === 'undefined') {
+        return;
+    }
+
+    try {
+        window.amplitude.setUserId(null);
+        window.amplitude.reset();
+        console.log('Amplitude: User cleared');
+    } catch (error) {
+        console.error('Error clearing Amplitude user:', error);
+    }
+}
+
+// ============================================================
 // IMAGE OPTIMIZATION (Pre-generated WebP versions)
 // ============================================================
 
@@ -695,6 +750,10 @@ window.SharedUtils = {
     truncateString,
     truncateLongWords,
     generateRandomNickname,
+
+    // Amplitude Analytics
+    identifyAmplitudeUser,
+    clearAmplitudeUser,
 
     // Session management
     generateSessionId,


### PR DESCRIPTION
Added user identification for Amplitude Analytics:

Features:
- Identify users when they sign in (link anonymous sessions)
- Track user properties: email, provider, nickname, created_at
- Clear user data on logout (reset Amplitude session)
- Works for both new sign-ins and already logged-in users

Implementation:
- Added identifyAmplitudeUser() in SharedUtils
- Added clearAmplitudeUser() in SharedUtils
- Integrated with auth state changes in script.js
- Calls identification after user profile loads

Benefits:
- Links anonymous pre-login behavior with post-login activity
- Tracks complete user journey across sessions
- Better understanding of user behavior and conversion
- Personalized analytics with user properties