### PR TITLE
Fix: Add Amplitude user identification to all pages

### DIFF
--- a/catalogue.js
+++ b/catalogue.js
@@ -1069,6 +1069,7 @@ function setupAuth() {
 
             // Load fresh profile and update UI
             await loadAndSetUserProfile(user);
+            SharedUtils.identifyAmplitudeUser(user, currentUserProfile); // Identify in Amplitude
             updateAuthUI(user);
         } else {
             updateAuthUI(null);
@@ -1102,6 +1103,7 @@ function setupAuthStateListener() {
             }
             currentUser = null;
             currentUserProfile = null;
+            SharedUtils.clearAmplitudeUser(); // Clear Amplitude user
             updateAuthUI(null);
             return;
         }
@@ -1117,6 +1119,7 @@ function setupAuthStateListener() {
                 }
                 updateAuthUI(user);
                 await loadAndSetUserProfile(user);
+                SharedUtils.identifyAmplitudeUser(user, currentUserProfile); // Identify in Amplitude
                 updateAuthUI(user);
             }
         }

--- a/index-static.js
+++ b/index-static.js
@@ -132,6 +132,7 @@ async function initializeAuth() {
 
             // Load fresh profile in background
             loadAndSetUserProfile(user).then(() => {
+                SharedUtils.identifyAmplitudeUser(user, currentUserProfile); // Identify in Amplitude
                 updateAuthUI(user);
             });
         } else {
@@ -165,6 +166,7 @@ function setupAuthStateListener() {
             }
             currentUser = null;
             currentUserProfile = null;
+            SharedUtils.clearAmplitudeUser(); // Clear Amplitude user
             updateAuthUI(null);
             return;
         }
@@ -178,6 +180,7 @@ function setupAuthStateListener() {
                 }
                 updateAuthUI(user);
                 await loadAndSetUserProfile(user);
+                SharedUtils.identifyAmplitudeUser(user, currentUserProfile); // Identify in Amplitude
                 updateAuthUI(user);
             }
         }

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -450,6 +450,7 @@ function setupAuth() {
 
             // Load fresh profile and update UI
             await loadAndSetUserProfile(user);
+            SharedUtils.identifyAmplitudeUser(user, currentUserProfile); // Identify in Amplitude
             updateAuthUI(user);
         } else {
             updateAuthUI(null);
@@ -482,6 +483,7 @@ function setupAuthStateListener() {
             }
             currentUser = null;
             currentUserProfile = null;
+            SharedUtils.clearAmplitudeUser(); // Clear Amplitude user
             updateAuthUI(null);
             return;
         }
@@ -496,6 +498,7 @@ function setupAuthStateListener() {
                 }
                 updateAuthUI(user);
                 await loadAndSetUserProfile(user);
+            SharedUtils.identifyAmplitudeUser(user, currentUserProfile); // Identify in Amplitude
                 updateAuthUI(user);
             }
         }

--- a/map.js
+++ b/map.js
@@ -250,6 +250,7 @@ function setupAuth() {
             }
 
             await loadAndSetUserProfile(user);
+            SharedUtils.identifyAmplitudeUser(user, currentUserProfile); // Identify in Amplitude
             updateAuthUI(user);
         } else {
             updateAuthUI(null);
@@ -275,6 +276,7 @@ function setupAuthStateListener() {
             }
             currentUser = null;
             currentUserProfile = null;
+            SharedUtils.clearAmplitudeUser(); // Clear Amplitude user
             updateAuthUI(null);
             return;
         }
@@ -288,6 +290,7 @@ function setupAuthStateListener() {
                 }
                 updateAuthUI(user);
                 await loadAndSetUserProfile(user);
+            SharedUtils.identifyAmplitudeUser(user, currentUserProfile); // Identify in Amplitude
                 updateAuthUI(user);
             }
         }

--- a/profile.js
+++ b/profile.js
@@ -421,6 +421,7 @@ function setupAuth() {
 
             // Load fresh profile and update UI
             await loadAndSetUserProfile(user);
+            SharedUtils.identifyAmplitudeUser(user, currentUserProfile); // Identify in Amplitude
             updateAuthUI(user);
         } else {
             updateAuthUI(null);
@@ -454,6 +455,7 @@ function setupAuthStateListener() {
             }
             currentUser = null;
             currentUserProfile = null;
+            SharedUtils.clearAmplitudeUser(); // Clear Amplitude user
             updateAuthUI(null);
             return;
         }
@@ -469,6 +471,7 @@ function setupAuthStateListener() {
                 }
                 updateAuthUI(user);
                 await loadAndSetUserProfile(user);
+            SharedUtils.identifyAmplitudeUser(user, currentUserProfile); // Identify in Amplitude
                 updateAuthUI(user);
             }
         }

--- a/stickerlog.js
+++ b/stickerlog.js
@@ -409,6 +409,7 @@ function setupAuth() {
 
             // Load fresh profile and update UI
             await loadAndSetUserProfile(user);
+            SharedUtils.identifyAmplitudeUser(user, currentUserProfile); // Identify in Amplitude
             updateAuthUI(user);
         } else {
             updateAuthUI(null);
@@ -440,6 +441,7 @@ function setupAuthStateListener() {
             }
             currentUser = null;
             currentUserProfile = null;
+            SharedUtils.clearAmplitudeUser(); // Clear Amplitude user
             updateAuthUI(null);
             return;
         }
@@ -454,6 +456,7 @@ function setupAuthStateListener() {
                 }
                 updateAuthUI(user);
                 await loadAndSetUserProfile(user);
+            SharedUtils.identifyAmplitudeUser(user, currentUserProfile); // Identify in Amplitude
                 updateAuthUI(user);
             }
         }

--- a/stickerstat.js
+++ b/stickerstat.js
@@ -540,6 +540,7 @@ function setupAuth() {
             }
 
             await loadAndSetUserProfile(user);
+            SharedUtils.identifyAmplitudeUser(user, currentUserProfile); // Identify in Amplitude
             updateAuthUI(user);
         } else {
             updateAuthUI(null);
@@ -565,6 +566,7 @@ function setupAuthStateListener() {
             }
             currentUser = null;
             currentUserProfile = null;
+            SharedUtils.clearAmplitudeUser(); // Clear Amplitude user
             updateAuthUI(null);
             return;
         }
@@ -578,6 +580,7 @@ function setupAuthStateListener() {
                 }
                 updateAuthUI(user);
                 await loadAndSetUserProfile(user);
+            SharedUtils.identifyAmplitudeUser(user, currentUserProfile); // Identify in Amplitude
                 updateAuthUI(user);
             }
         }


### PR DESCRIPTION
Extended Amplitude user identification to all pages with auth:

Updated files:
- index-static.js (home page)
- catalogue.js
- leaderboard.js
- map.js
- profile.js
- stickerlog.js
- stickerstat.js

Changes:
- Added identifyAmplitudeUser() on user sign-in
- Added identifyAmplitudeUser() on initial session load
- Added clearAmplitudeUser() on sign-out

This ensures users are properly identified in Amplitude regardless of which page they visit or sign in from.