### PR TITLE
Fix: Enable logout button on all static pages

### DIFF
--- a/countries/ARG.html
+++ b/countries/ARG.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/ARM.html
+++ b/countries/ARM.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/AUT.html
+++ b/countries/AUT.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/BEL.html
+++ b/countries/BEL.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/BGR.html
+++ b/countries/BGR.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/BIH.html
+++ b/countries/BIH.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/BLR.html
+++ b/countries/BLR.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/BRA.html
+++ b/countries/BRA.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/CAN.html
+++ b/countries/CAN.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/CHE.html
+++ b/countries/CHE.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/CHL.html
+++ b/countries/CHL.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/COL.html
+++ b/countries/COL.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/CYP.html
+++ b/countries/CYP.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/CZE.html
+++ b/countries/CZE.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/DEU.html
+++ b/countries/DEU.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/DNK.html
+++ b/countries/DNK.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/ENG.html
+++ b/countries/ENG.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/ESP.html
+++ b/countries/ESP.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/EST.html
+++ b/countries/EST.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/FIN.html
+++ b/countries/FIN.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/FRA.html
+++ b/countries/FRA.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/GEO.html
+++ b/countries/GEO.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/GRC.html
+++ b/countries/GRC.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/HRV.html
+++ b/countries/HRV.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/HUN.html
+++ b/countries/HUN.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/IRL.html
+++ b/countries/IRL.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/ISR.html
+++ b/countries/ISR.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/ITA.html
+++ b/countries/ITA.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/JPN.html
+++ b/countries/JPN.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/KAZ.html
+++ b/countries/KAZ.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/LIE.html
+++ b/countries/LIE.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/LUX.html
+++ b/countries/LUX.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/LVA.html
+++ b/countries/LVA.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/MAR.html
+++ b/countries/MAR.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/MCO.html
+++ b/countries/MCO.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/MEX.html
+++ b/countries/MEX.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/MNE.html
+++ b/countries/MNE.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/NIR.html
+++ b/countries/NIR.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/NLD.html
+++ b/countries/NLD.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/NOR.html
+++ b/countries/NOR.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/POL.html
+++ b/countries/POL.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/PRT.html
+++ b/countries/PRT.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/ROU.html
+++ b/countries/ROU.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/RUS.html
+++ b/countries/RUS.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/SCO.html
+++ b/countries/SCO.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/SRB.html
+++ b/countries/SRB.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/SVK.html
+++ b/countries/SVK.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/SVN.html
+++ b/countries/SVN.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/SWE.html
+++ b/countries/SWE.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/TUR.html
+++ b/countries/TUR.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/UKR.html
+++ b/countries/UKR.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/URY.html
+++ b/countries/URY.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/USA.html
+++ b/countries/USA.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/countries/WLS.html
+++ b/countries/WLS.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>

--- a/templates/country-page.html
+++ b/templates/country-page.html
@@ -101,6 +101,7 @@
     </footer>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="/shared.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The logout button wasn't working on static pages (stickers, clubs, countries) because they didn't have auth setup JavaScript.

Changes:
- Add auto-initialization for auth in shared.js that runs on DOMContentLoaded
- Add Supabase client library to country-page template
- Update all existing country HTML files with Supabase script tag

The auto-init code checks if the page has its own auth setup script and skips initialization if so, avoiding duplicate event handlers.