### PR TITLE
Fix sticker page layout to prevent content shifting

### DIFF
--- a/style.css
+++ b/style.css
@@ -948,6 +948,56 @@ body.quiz-result .result-right-panel {
     margin-top: calc(var(--spacing-unit) * 4);
 }
 
+/* Sticker Page Container - ensures consistent layout across all sticker pages */
+.sticker-page-container {
+    max-width: none;
+    width: 100%;
+    padding: 0;
+}
+
+.sticker-page-content-wrapper {
+    width: 100%;
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 0 calc(var(--spacing-unit) * 2);
+}
+
+/* Desktop: expand sticker page wrapper to match two-column layout */
+@media (min-width: 1000px) {
+    .sticker-page-content-wrapper {
+        max-width: 1000px;
+    }
+
+    /* Remove the breakout positioning since wrapper controls width now */
+    .sticker-page-container .sticker-detail-two-column {
+        width: 100%;
+        max-width: none;
+        position: static;
+        left: auto;
+        transform: none;
+    }
+}
+
+/* Tablet: sticker page wrapper matches container width */
+@media (min-width: 701px) and (max-width: 999px) {
+    .sticker-page-content-wrapper {
+        max-width: 800px;
+    }
+
+    .sticker-page-container .sticker-detail-two-column {
+        width: 100%;
+        max-width: none;
+    }
+}
+
+/* Mobile: full width with padding */
+@media (max-width: 700px) {
+    .sticker-page-content-wrapper {
+        max-width: 100%;
+        padding: 0 calc(var(--spacing-unit) * 1.5);
+    }
+}
+
 .sticker-map-label {
     font-size: 1.2em;
     margin-bottom: calc(var(--spacing-unit) * 1.5);

--- a/templates/sticker-page.html
+++ b/templates/sticker-page.html
@@ -83,35 +83,37 @@
          </div>
     </header>
 
-    <main class="container" id="catalogue-container">
-        <div id="catalogue-breadcrumbs">{{BREADCRUMBS}}</div>
+    <main class="container sticker-page-container" id="catalogue-container">
+        <div class="sticker-page-content-wrapper">
+            <div id="catalogue-breadcrumbs">{{BREADCRUMBS}}</div>
 
-        <h1 id="main-catalogue-heading" style="display: none;">{{MAIN_HEADING}}</h1>
+            <h1 id="main-catalogue-heading" style="display: none;">{{MAIN_HEADING}}</h1>
 
-        <div id="catalogue-content">
-            <div class="sticker-detail-view sticker-detail-two-column">
-                <div class="sticker-detail-left-column">
-                    <div class="sticker-detail-image-container" onclick="window.open('{{IMAGE_FULL_URL}}', '_blank')">
-                        <img src="{{IMAGE_URL}}"
-                             alt="{{IMAGE_ALT}}"
-                             class="sticker-detail-image"
-                             decoding="async"
-                             loading="eager"
-                             fetchpriority="high">
+            <div id="catalogue-content">
+                <div class="sticker-detail-view sticker-detail-two-column">
+                    <div class="sticker-detail-left-column">
+                        <div class="sticker-detail-image-container" onclick="window.open('{{IMAGE_FULL_URL}}', '_blank')">
+                            <img src="{{IMAGE_URL}}"
+                                 alt="{{IMAGE_ALT}}"
+                                 class="sticker-detail-image"
+                                 decoding="async"
+                                 loading="eager"
+                                 fetchpriority="high">
+                        </div>
+                        {{NAVIGATION_BUTTONS}}
                     </div>
-                    {{NAVIGATION_BUTTONS}}
-                </div>
 
-                <div class="sticker-detail-right-panel">
-                    <div class="sticker-detail-info-block">
-                        <h2 class="sticker-detail-club-name">{{CLUB_NAME}}</h2>
-                        <p class="sticker-detail-id">#{{STICKER_ID}}</p>
-                        {{STICKER_DATE}}
-                        {{STICKER_LOCATION}}
+                    <div class="sticker-detail-right-panel">
+                        <div class="sticker-detail-info-block">
+                            <h2 class="sticker-detail-club-name">{{CLUB_NAME}}</h2>
+                            <p class="sticker-detail-id">#{{STICKER_ID}}</p>
+                            {{STICKER_DATE}}
+                            {{STICKER_LOCATION}}
+                        </div>
                     </div>
                 </div>
+                {{MAP_SECTION}}
             </div>
-            {{MAP_SECTION}}
         </div>
     </main>
 


### PR DESCRIPTION
Add wrapper container (.sticker-page-content-wrapper) to ensure consistent widths for breadcrumbs and sticker content. Previously, breadcrumbs had different width constraints than the two-column layout, causing visual misalignment when breadcrumb text varied in length.

Changes:
- Add sticker-page-container class to main container for sticker pages
- Introduce sticker-page-content-wrapper for unified width control
- Align breadcrumbs with two-column content on all breakpoints
- Desktop (≥1000px): both use 1000px max-width
- Tablet (701-999px): both use 800px max-width
- Mobile (≤700px): full width with padding