### PR TITLE
Improve battle page UX and add dynamic rating loading

### DIFF
--- a/battle.html
+++ b/battle.html
@@ -70,7 +70,6 @@
         <div class="battle-page-content-wrapper">
             <div id="battle-header">
                 <h1>Which sticker is better?</h1>
-                <p class="battle-subtitle">Click on your favorite to vote</p>
                 <div id="battle-stats" class="battle-stats">
                     <span id="total-votes">Loading...</span>
                 </div>
@@ -92,10 +91,6 @@
                         <div class="battle-sticker-overlay">
                             <span class="vote-text">Vote</span>
                         </div>
-                    </div>
-
-                    <div class="battle-vs">
-                        <span>VS</span>
                     </div>
 
                     <div class="battle-sticker battle-sticker-right" id="sticker-b" data-id="">
@@ -121,6 +116,12 @@
             <div id="battle-error" class="battle-error" style="display: none;">
                 <p>Failed to load stickers. Please try again.</p>
                 <button class="btn btn-primary" onclick="loadNewPair()">Retry</button>
+            </div>
+
+            <!-- Navigation buttons -->
+            <div class="battle-actions">
+                <a href="/quiz.html" class="btn btn-primary">Play Quiz</a>
+                <a href="/catalogue.html" class="btn btn-nav">View Catalogue</a>
             </div>
         </div>
     </main>

--- a/scripts/generate-static-pages.js
+++ b/scripts/generate-static-pages.js
@@ -186,20 +186,6 @@ function generateStickerLocation(sticker) {
 }
 
 /**
- * Generate sticker rating HTML with rank link
- * Shows: Rate: 1520 (#123) with link to battle page
- */
-function generateStickerRating(sticker, rank) {
-    // Only show if sticker has rating data (games > 0) or if we want to always show
-    const rating = sticker.rating || 1500;
-    const hasGames = sticker.games && sticker.games > 0;
-
-    // Always show rating with link to battle, even for new stickers
-    const rankText = rank ? ` (#${rank})` : '';
-    return `<p class="sticker-detail-rating"><a href="/battle.html">Rate: ${rating}${rankText}</a></p>`;
-}
-
-/**
  * Generate navigation buttons HTML (formatted like current site)
  */
 function generateNavigationButtons(prevId, nextId) {
@@ -474,7 +460,7 @@ function generateClubMapInitScript(stickersWithCoordinates, clubName) {
 /**
  * Generate a single sticker page
  */
-async function generateStickerPage(sticker, club, prevStickerId, nextStickerId, allStickers = [], stickerRanks = {}) {
+async function generateStickerPage(sticker, club, prevStickerId, nextStickerId, allStickers = []) {
     const template = loadTemplate('sticker-page.html');
 
     const countryName = getCountryName(club.country);
@@ -502,9 +488,6 @@ async function generateStickerPage(sticker, club, prevStickerId, nextStickerId, 
     // Find nearby stickers for map (50km radius, max 10)
     const nearbyStickers = findNearbyStickers(sticker, allStickers, 50, 10);
 
-    // Get rank for this sticker
-    const rank = stickerRanks[sticker.id] || null;
-
     const data = {
         PAGE_TITLE: pageTitle,
         META_DESCRIPTION: metaDescription,
@@ -519,7 +502,6 @@ async function generateStickerPage(sticker, club, prevStickerId, nextStickerId, 
         MAIN_HEADING: `Sticker #${sticker.id}`,
         STICKER_ID: sticker.id,
         CLUB_NAME: club.name,
-        STICKER_RATING: generateStickerRating(sticker, rank),
         STICKER_DATE: generateStickerDate(sticker),
         STICKER_LOCATION: generateStickerLocation(sticker),
         NAVIGATION_BUTTONS: generateNavigationButtons(prevStickerId, nextStickerId),
@@ -843,18 +825,6 @@ async function generateAllPages() {
 
         console.log(`  ✓ Found ${Object.keys(clubsByCountry).length} countries`);
 
-        // Calculate sticker ranks based on rating (for ELO display)
-        console.log('\n📊 Calculating sticker ranks...');
-        const stickerRanks = {};
-        const sortedByRating = [...stickers]
-            .filter(s => s.rating !== null && s.rating !== undefined)
-            .sort((a, b) => (b.rating || 1500) - (a.rating || 1500));
-
-        sortedByRating.forEach((sticker, index) => {
-            stickerRanks[sticker.id] = index + 1;
-        });
-        console.log(`  ✓ Calculated ranks for ${Object.keys(stickerRanks).length} stickers`);
-
         // Generate sticker pages (pass all stickers for nearby calculation)
         console.log();
         console.log('🔨 Generating sticker pages...');
@@ -867,7 +837,7 @@ async function generateAllPages() {
             const nextStickerId = i < stickers.length - 1 ? stickers[i + 1].id : null;
 
             try {
-                await generateStickerPage(sticker, sticker.clubs, prevStickerId, nextStickerId, stickers, stickerRanks);
+                await generateStickerPage(sticker, sticker.clubs, prevStickerId, nextStickerId, stickers);
                 stickerSuccess++;
 
                 if (stickerSuccess % 100 === 0 || stickerSuccess === stickers.length) {

--- a/style.css
+++ b/style.css
@@ -2643,3 +2643,28 @@ body.ttr-mode .game-info #timer {
         text-decoration: underline;
     }
 }
+
+/* Battle page action buttons */
+.battle-actions {
+    display: flex;
+    justify-content: center;
+    gap: calc(var(--spacing-unit) * 2);
+    margin-top: calc(var(--spacing-unit) * 4);
+}
+
+.battle-actions .btn {
+    min-width: 160px;
+}
+
+@media (max-width: 500px) {
+    .battle-actions {
+        flex-direction: column;
+        align-items: center;
+        gap: calc(var(--spacing-unit) * 1.5);
+    }
+
+    .battle-actions .btn {
+        width: 100%;
+        max-width: 280px;
+    }
+}

--- a/templates/sticker-page.html
+++ b/templates/sticker-page.html
@@ -107,7 +107,9 @@
                         <div class="sticker-detail-info-block">
                             <h2 class="sticker-detail-club-name">{{CLUB_NAME}}</h2>
                             <p class="sticker-detail-id">#{{STICKER_ID}}</p>
-                            {{STICKER_RATING}}
+                            <p class="sticker-detail-rating" id="sticker-rating" data-sticker-id="{{STICKER_ID}}">
+                                <a href="/battle.html">Rate: <span id="rating-value">...</span> (<span id="rating-rank">#...</span>)</a>
+                            </p>
                             {{STICKER_DATE}}
                             {{STICKER_LOCATION}}
                         </div>
@@ -134,6 +136,36 @@
     <script>
         // Initialize map if map container exists
         {{MAP_INIT_SCRIPT}}
+
+        // Load dynamic rating from database
+        document.addEventListener('DOMContentLoaded', async function() {
+            const ratingEl = document.getElementById('sticker-rating');
+            if (!ratingEl) return;
+
+            const stickerId = parseInt(ratingEl.dataset.stickerId);
+            if (!stickerId) return;
+
+            try {
+                const supabase = getSupabaseClient();
+                if (!supabase) return;
+
+                const { data, error } = await supabase.rpc('get_sticker_rank', {
+                    p_sticker_id: stickerId
+                });
+
+                if (error) {
+                    console.error('Error loading rating:', error);
+                    return;
+                }
+
+                if (data && !data.error) {
+                    document.getElementById('rating-value').textContent = data.rating;
+                    document.getElementById('rating-rank').textContent = '#' + data.rank;
+                }
+            } catch (err) {
+                console.error('Error loading rating:', err);
+            }
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
- Remove VS indicator between stickers
- Remove subtitle "Click on your favorite to vote"
- Add Play Quiz and View Catalogue buttons below stickers
- Make sticker page rating load dynamically from database
- Remove static rating generation (now fetched via RPC)

Rating now updates in real-time without page regeneration.