### PR TITLE
Fix Edge Function slug in sticker page template

### DIFF
--- a/templates/sticker-page.html
+++ b/templates/sticker-page.html
@@ -372,7 +372,7 @@
                         clubsToRegenerate.push(oldClubId);
                     }
 
-                    const { error: regenError } = await supabase.functions.invoke('trigger-regeneration', {
+                    const { error: regenError } = await supabase.functions.invoke('supabase-functions-new-trigger-regeneration', {
                         body: {
                             sticker_ids: pagesToRegenerate,
                             club_ids: clubsToRegenerate


### PR DESCRIPTION
Use actual Supabase function slug 'supabase-functions-new-trigger-regeneration' instead of the display name 'trigger-regeneration'.