### PR TITLE
Add club page regeneration when stickers are moved

### DIFF
--- a/.github/workflows/generate-sticker-pages.yml
+++ b/.github/workflows/generate-sticker-pages.yml
@@ -47,13 +47,21 @@ jobs:
             else
               STICKER_IDS="${{ github.event.client_payload.sticker_id }}"
             fi
+            # Get club_ids if provided (for regenerating old club/country pages)
+            CLUB_IDS="${{ github.event.client_payload.club_ids }}"
           else
             STICKER_IDS="${{ github.event.inputs.sticker_ids }}"
+            CLUB_IDS=""
           fi
           # Remove spaces and store
           STICKER_IDS=$(echo "$STICKER_IDS" | tr -d ' ')
+          CLUB_IDS=$(echo "$CLUB_IDS" | tr -d ' ')
           echo "sticker_ids=$STICKER_IDS" >> $GITHUB_OUTPUT
+          echo "club_ids=$CLUB_IDS" >> $GITHUB_OUTPUT
           echo "Processing sticker IDs: $STICKER_IDS"
+          if [ -n "$CLUB_IDS" ]; then
+            echo "Additional club IDs to regenerate: $CLUB_IDS"
+          fi
 
       - name: Generate sticker pages
         id: generate-pages
@@ -81,6 +89,17 @@ jobs:
 
           echo "page_generation=success" >> $GITHUB_OUTPUT
           echo "generated_urls=$GENERATED_URLS" >> $GITHUB_OUTPUT
+
+      - name: Regenerate club pages
+        if: steps.get-sticker-ids.outputs.club_ids != ''
+        working-directory: ./scripts
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        run: |
+          CLUB_IDS="${{ steps.get-sticker-ids.outputs.club_ids }}"
+          echo "Regenerating pages for clubs: $CLUB_IDS"
+          node regenerate-club-pages.js "$CLUB_IDS"
 
       - name: Optimize images
         id: optimize-images

--- a/scripts/regenerate-club-pages.js
+++ b/scripts/regenerate-club-pages.js
@@ -1,0 +1,393 @@
+#!/usr/bin/env node
+
+/**
+ * Regenerate club and country pages by club IDs
+ * This script is used when stickers are moved between clubs
+ * to update the sticker counts on affected club and country pages
+ *
+ * Usage: node regenerate-club-pages.js <club_ids>
+ * Example: node regenerate-club-pages.js 123,456
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import dotenv from 'dotenv';
+
+// Load environment variables
+const PROJECT_ROOT_FOR_ENV = join(dirname(fileURLToPath(import.meta.url)), '..');
+dotenv.config({ path: join(PROJECT_ROOT_FOR_ENV, '.env') });
+
+// Configuration
+const SUPABASE_URL = process.env.SUPABASE_URL || "https://rbmeslzlbsolkxnvesqb.supabase.co";
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJibWVzbHpsYnNvbGt4bnZlc3FiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDUwODcxMzYsImV4cCI6MjA2MDY2MzEzNn0.cu-Qw0WoEslfKXXCiMocWFg6Uf1sK_cQYcyP2mT0-Nw";
+const BASE_URL = "https://stickerhunt.club";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PROJECT_ROOT = join(__dirname, '..');
+
+// Get club IDs from command line
+const clubIdsArg = process.argv[2] || process.env.CLUB_IDS;
+
+if (!clubIdsArg) {
+    console.log('No club IDs provided, skipping club page regeneration');
+    process.exit(0);
+}
+
+const clubIds = clubIdsArg.split(',').map(id => parseInt(id.trim())).filter(id => !isNaN(id));
+
+if (clubIds.length === 0) {
+    console.log('No valid club IDs provided');
+    process.exit(0);
+}
+
+console.log(`🔄 Regenerating pages for clubs: ${clubIds.join(', ')}\n`);
+
+// Initialize Supabase client
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+// Country code mapping
+const COUNTRY_NAMES = {
+    'AFG': 'Afghanistan', 'ALB': 'Albania', 'DZA': 'Algeria', 'AND': 'Andorra',
+    'AGO': 'Angola', 'ARG': 'Argentina', 'ARM': 'Armenia', 'AUS': 'Australia',
+    'AUT': 'Austria', 'AZE': 'Azerbaijan', 'BHS': 'Bahamas', 'BHR': 'Bahrain',
+    'BGD': 'Bangladesh', 'BLR': 'Belarus', 'BEL': 'Belgium', 'BLZ': 'Belize',
+    'BEN': 'Benin', 'BOL': 'Bolivia', 'BIH': 'Bosnia and Herzegovina',
+    'BWA': 'Botswana', 'BRA': 'Brazil', 'BGR': 'Bulgaria', 'BFA': 'Burkina Faso',
+    'KHM': 'Cambodia', 'CMR': 'Cameroon', 'CAN': 'Canada', 'CPV': 'Cape Verde',
+    'CAF': 'Central African Republic', 'TCD': 'Chad', 'CHL': 'Chile', 'CHN': 'China',
+    'COL': 'Colombia', 'COG': 'Congo', 'CRI': 'Costa Rica', 'HRV': 'Croatia',
+    'CUB': 'Cuba', 'CYP': 'Cyprus', 'CZE': 'Czech Republic', 'DNK': 'Denmark',
+    'DJI': 'Djibouti', 'DOM': 'Dominican Republic', 'ECU': 'Ecuador', 'EGY': 'Egypt',
+    'SLV': 'El Salvador', 'GNQ': 'Equatorial Guinea', 'EST': 'Estonia', 'ETH': 'Ethiopia',
+    'FJI': 'Fiji', 'FIN': 'Finland', 'FRA': 'France', 'GAB': 'Gabon', 'GMB': 'Gambia',
+    'GEO': 'Georgia', 'DEU': 'Germany', 'GHA': 'Ghana', 'GRC': 'Greece',
+    'GTM': 'Guatemala', 'GIN': 'Guinea', 'HTI': 'Haiti', 'HND': 'Honduras',
+    'HUN': 'Hungary', 'ISL': 'Iceland', 'IND': 'India', 'IDN': 'Indonesia',
+    'IRN': 'Iran', 'IRQ': 'Iraq', 'IRL': 'Ireland', 'ISR': 'Israel', 'ITA': 'Italy',
+    'CIV': 'Ivory Coast', 'JAM': 'Jamaica', 'JPN': 'Japan', 'JOR': 'Jordan',
+    'KAZ': 'Kazakhstan', 'KEN': 'Kenya', 'KWT': 'Kuwait', 'KGZ': 'Kyrgyzstan',
+    'LVA': 'Latvia', 'LBN': 'Lebanon', 'LBR': 'Liberia', 'LBY': 'Libya',
+    'LIE': 'Liechtenstein', 'LTU': 'Lithuania', 'LUX': 'Luxembourg',
+    'MKD': 'North Macedonia', 'MDG': 'Madagascar', 'MWI': 'Malawi', 'MYS': 'Malaysia',
+    'MLI': 'Mali', 'MLT': 'Malta', 'MRT': 'Mauritania', 'MEX': 'Mexico',
+    'MDA': 'Moldova', 'MCO': 'Monaco', 'MNG': 'Mongolia', 'MNE': 'Montenegro',
+    'MAR': 'Morocco', 'MOZ': 'Mozambique', 'NPL': 'Nepal', 'NLD': 'Netherlands',
+    'NZL': 'New Zealand', 'NIC': 'Nicaragua', 'NER': 'Niger', 'NGA': 'Nigeria',
+    'PRK': 'North Korea', 'NOR': 'Norway', 'OMN': 'Oman', 'PAK': 'Pakistan',
+    'PAN': 'Panama', 'PNG': 'Papua New Guinea', 'PRY': 'Paraguay', 'PER': 'Peru',
+    'PHL': 'Philippines', 'POL': 'Poland', 'PRT': 'Portugal', 'QAT': 'Qatar',
+    'ROU': 'Romania', 'RUS': 'Russia', 'RWA': 'Rwanda', 'SAU': 'Saudi Arabia',
+    'SEN': 'Senegal', 'SRB': 'Serbia', 'SLE': 'Sierra Leone', 'SGP': 'Singapore',
+    'SVK': 'Slovakia', 'SVN': 'Slovenia', 'SOM': 'Somalia', 'ZAF': 'South Africa',
+    'KOR': 'South Korea', 'ESP': 'Spain', 'LKA': 'Sri Lanka', 'SDN': 'Sudan',
+    'SWE': 'Sweden', 'CHE': 'Switzerland', 'SYR': 'Syria', 'TWN': 'Taiwan',
+    'TZA': 'Tanzania', 'THA': 'Thailand', 'TGO': 'Togo', 'TUN': 'Tunisia',
+    'TUR': 'Turkey', 'UGA': 'Uganda', 'UKR': 'Ukraine', 'ARE': 'United Arab Emirates',
+    'GBR': 'United Kingdom', 'USA': 'United States', 'URY': 'Uruguay',
+    'UZB': 'Uzbekistan', 'VEN': 'Venezuela', 'VNM': 'Vietnam', 'YEM': 'Yemen',
+    'ZMB': 'Zambia', 'ZWE': 'Zimbabwe',
+    'ENG': 'England', 'SCO': 'Scotland', 'WLS': 'Wales', 'NIR': 'Northern Ireland'
+};
+
+function getCountryName(code) {
+    return COUNTRY_NAMES[code?.toUpperCase()] || code;
+}
+
+function loadTemplate(templateName) {
+    const templatePath = join(PROJECT_ROOT, 'templates', templateName);
+    if (!existsSync(templatePath)) {
+        throw new Error(`Template not found: ${templatePath}`);
+    }
+    return readFileSync(templatePath, 'utf-8');
+}
+
+function replacePlaceholders(template, data) {
+    let result = template;
+    for (const [key, value] of Object.entries(data)) {
+        const placeholder = `{{${key}}}`;
+        result = result.replaceAll(placeholder, value || '');
+    }
+    return result;
+}
+
+function generateBreadcrumbs(links) {
+    return links.map(link => `<a href="${link.url}">${link.text}</a>`).join(' → ');
+}
+
+function getOptimizedImageUrl(imageUrl, suffix = '_web') {
+    if (!imageUrl) return imageUrl;
+    if (!imageUrl.includes('/storage/v1/object/')) return imageUrl;
+    try {
+        const url = new URL(imageUrl);
+        const pathname = url.pathname;
+        const lastDotIndex = pathname.lastIndexOf('.');
+        if (lastDotIndex === -1) {
+            url.pathname = pathname + suffix + '.webp';
+        } else {
+            url.pathname = pathname.substring(0, lastDotIndex) + suffix + '.webp';
+        }
+        return url.toString();
+    } catch (e) {
+        return imageUrl;
+    }
+}
+
+function getThumbnailUrl(imageUrl) {
+    return getOptimizedImageUrl(imageUrl, '_thumb');
+}
+
+function generateClubInfo(club) {
+    let html = '';
+    if (club.city) {
+        html += `<p class="club-info-item">🌍 ${club.city}</p>`;
+    }
+    if (club.web) {
+        const sanitizedUrl = encodeURI(club.web);
+        html += `<p class="club-info-item">🌐 <a href="${sanitizedUrl}" target="_blank" rel="noopener noreferrer">${club.web}</a></p>`;
+    }
+    if (club.media) {
+        html += `<p class="club-info-item">#️⃣ ${club.media}</p>`;
+    }
+    return html;
+}
+
+function generateStickerGallery(stickers, clubName) {
+    if (!stickers || stickers.length === 0) {
+        return '<p>No stickers found for this club.</p>';
+    }
+    let html = '';
+    stickers.forEach(sticker => {
+        const thumbnailUrl = getThumbnailUrl(sticker.image_url);
+        html += `
+                <a href="/stickers/${sticker.id}.html" class="sticker-preview-link">
+                    <img src="${thumbnailUrl}"
+                         alt="Sticker ID ${sticker.id} for ${clubName}"
+                         class="sticker-preview-image"
+                         loading="lazy"
+                         decoding="async">
+                </a>`;
+    });
+    return html;
+}
+
+function generateClubMapSection(stickersWithCoordinates) {
+    if (!stickersWithCoordinates || stickersWithCoordinates.length === 0) {
+        return '';
+    }
+    return `
+            <div class="club-map-section">
+                <h3 class="club-map-heading">Sticker Locations</h3>
+                <div id="club-map" class="club-map-container"></div>
+                <div class="view-map-btn-container">
+                    <a href="/map.html" class="btn btn-nav">View Full Map</a>
+                </div>
+            </div>
+        `;
+}
+
+function generateClubMapInitScript(stickersWithCoordinates, clubName) {
+    if (!stickersWithCoordinates || stickersWithCoordinates.length === 0) {
+        return '';
+    }
+    const avgLat = stickersWithCoordinates.reduce((sum, s) => sum + s.latitude, 0) / stickersWithCoordinates.length;
+    const avgLng = stickersWithCoordinates.reduce((sum, s) => sum + s.longitude, 0) / stickersWithCoordinates.length;
+    const escapedClubName = clubName.replace(/'/g, "\\'");
+    const markers = stickersWithCoordinates.map(sticker => {
+        return `
+                (function() {
+                    const marker = L.marker([${sticker.latitude}, ${sticker.longitude}]).addTo(clubMap);
+                    marker.bindPopup('<div class="nearby-sticker-popup"><strong>${escapedClubName}</strong><a href="/stickers/${sticker.id}.html" class="map-popup-link">View</a></div>');
+                    marker.on('mouseover', function() { this.openPopup(); });
+                    marker.on('click', function() { this.openPopup(); });
+                })();`;
+    }).join('\n');
+    return `
+        document.addEventListener('DOMContentLoaded', function() {
+            if (typeof L !== 'undefined' && document.getElementById('club-map')) {
+                const clubMap = L.map('club-map').setView([${avgLat}, ${avgLng}], 10);
+                L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                    attribution: '© OpenStreetMap contributors'
+                }).addTo(clubMap);
+                ${markers}
+                ${stickersWithCoordinates.length > 1 ? `
+                const bounds = L.latLngBounds([
+                    ${stickersWithCoordinates.map(s => `[${s.latitude}, ${s.longitude}]`).join(',\n                    ')}
+                ]);
+                clubMap.fitBounds(bounds, { padding: [30, 30], maxZoom: 13 });
+                ` : ''}
+            }
+        });
+    `;
+}
+
+async function generateClubPage(club, stickers) {
+    const template = loadTemplate('club-page.html');
+    const countryName = getCountryName(club.country);
+    const pageTitle = `${club.name} - ${countryName} - Sticker Catalogue`;
+    const stickerCount = stickers ? stickers.length : 0;
+    const metaDescription = `View ${stickerCount} stickers from ${club.name} (${countryName}) in our football sticker collection.`;
+    const canonicalUrl = `${BASE_URL}/clubs/${club.id}.html`;
+
+    let keywords = `football stickers, ${club.name}, ${countryName}, panini, sticker collection`;
+    if (club.media) {
+        const cleanMedia = club.media.replace(/[#\uD800-\uDFFF]/g, '').trim();
+        if (cleanMedia) keywords += ', ' + cleanMedia;
+    }
+
+    const breadcrumbs = generateBreadcrumbs([
+        { text: 'Catalogue', url: '/catalogue.html' },
+        { text: countryName, url: `/countries/${club.country.toUpperCase()}.html` },
+        { text: club.name, url: `/clubs/${club.id}.html` }
+    ]);
+
+    const stickersWithCoordinates = stickers ? stickers.filter(
+        s => s.latitude != null && s.longitude != null
+    ) : [];
+
+    const ogImage = stickers && stickers.length > 0
+        ? stickers[0].image_url
+        : 'https://stickerhunt.club/metash.png';
+
+    const data = {
+        PAGE_TITLE: pageTitle,
+        META_DESCRIPTION: metaDescription,
+        META_KEYWORDS: keywords,
+        CANONICAL_URL: canonicalUrl,
+        OG_IMAGE: ogImage,
+        CLUB_NAME: club.name,
+        BREADCRUMBS: breadcrumbs,
+        MAIN_HEADING: `${club.name} - Sticker Gallery`,
+        CLUB_INFO: generateClubInfo(club),
+        STICKER_GALLERY: generateStickerGallery(stickers, club.name),
+        CLUB_MAP_SECTION: generateClubMapSection(stickersWithCoordinates),
+        CLUB_MAP_INIT_SCRIPT: generateClubMapInitScript(stickersWithCoordinates, club.name)
+    };
+
+    const html = replacePlaceholders(template, data);
+    const outputDir = join(PROJECT_ROOT, 'clubs');
+    if (!existsSync(outputDir)) mkdirSync(outputDir, { recursive: true });
+    const outputPath = join(outputDir, `${club.id}.html`);
+    writeFileSync(outputPath, html, 'utf-8');
+    return outputPath;
+}
+
+async function generateCountryPage(countryCode, clubs, stickerCountsByClub) {
+    const template = loadTemplate('country-page.html');
+    const countryName = getCountryName(countryCode);
+    const pageTitle = `${countryName} - Sticker Catalogue`;
+    const metaDescription = `Browse ${clubs.length} football clubs from ${countryName} in our sticker database.`;
+    const canonicalUrl = `${BASE_URL}/countries/${countryCode.toUpperCase()}.html`;
+    const keywords = `football stickers, ${countryName}, panini catalogue, football clubs, sticker collection`;
+
+    const breadcrumbs = generateBreadcrumbs([
+        { text: 'Catalogue', url: '/catalogue.html' },
+        { text: countryName, url: `/countries/${countryCode.toUpperCase()}.html` }
+    ]);
+
+    const clubsWithStickerCounts = clubs.map(club => ({
+        ...club,
+        stickerCount: stickerCountsByClub[club.id] || 0
+    }));
+    clubsWithStickerCounts.sort((a, b) => a.name.localeCompare(b.name));
+
+    let clubListHtml = '';
+    clubsWithStickerCounts.forEach(club => {
+        const countText = `(${club.stickerCount} sticker${club.stickerCount !== 1 ? 's' : ''})`;
+        clubListHtml += `<li><a href="/clubs/${club.id}.html">${club.name} ${countText}</a></li>`;
+    });
+
+    const data = {
+        PAGE_TITLE: pageTitle,
+        META_DESCRIPTION: metaDescription,
+        META_KEYWORDS: keywords,
+        CANONICAL_URL: canonicalUrl,
+        OG_IMAGE: 'https://stickerhunt.club/metash.png',
+        COUNTRY_NAME: countryName,
+        CLUB_COUNT: clubs.length,
+        BREADCRUMBS: breadcrumbs,
+        MAIN_HEADING: countryName,
+        CLUB_LIST: clubListHtml
+    };
+
+    const html = replacePlaceholders(template, data);
+    const outputDir = join(PROJECT_ROOT, 'countries');
+    if (!existsSync(outputDir)) mkdirSync(outputDir, { recursive: true });
+    const outputPath = join(outputDir, `${countryCode.toUpperCase()}.html`);
+    writeFileSync(outputPath, html, 'utf-8');
+    return outputPath;
+}
+
+async function regenerateClubPages() {
+    try {
+        // Fetch clubs by IDs
+        const { data: clubs, error: clubsError } = await supabase
+            .from('clubs')
+            .select('*')
+            .in('id', clubIds);
+
+        if (clubsError) throw clubsError;
+        if (!clubs || clubs.length === 0) {
+            console.log('No clubs found with provided IDs');
+            return;
+        }
+
+        // Get all sticker counts
+        const { data: allStickers } = await supabase
+            .from('stickers')
+            .select('id, club_id');
+
+        const stickerCountsByClub = {};
+        if (allStickers) {
+            allStickers.forEach(s => {
+                stickerCountsByClub[s.club_id] = (stickerCountsByClub[s.club_id] || 0) + 1;
+            });
+        }
+
+        // Track which countries need regeneration
+        const countriesToRegenerate = new Set();
+
+        // Regenerate club pages
+        for (const club of clubs) {
+            console.log(`\n📦 Processing club: ${club.name} (ID: ${club.id})`);
+
+            // Get stickers for this club
+            const { data: clubStickers } = await supabase
+                .from('stickers')
+                .select('*')
+                .eq('club_id', club.id)
+                .order('id', { ascending: true });
+
+            const clubPath = await generateClubPage(club, clubStickers || []);
+            console.log(`  ✓ Generated: ${clubPath}`);
+
+            countriesToRegenerate.add(club.country.toUpperCase());
+        }
+
+        // Regenerate country pages
+        for (const countryCode of countriesToRegenerate) {
+            console.log(`\n🌍 Regenerating country page: ${countryCode}`);
+
+            const { data: countryClubs } = await supabase
+                .from('clubs')
+                .select('*')
+                .ilike('country', countryCode)
+                .order('name');
+
+            if (countryClubs && countryClubs.length > 0) {
+                const countryPath = await generateCountryPage(countryCode, countryClubs, stickerCountsByClub);
+                console.log(`  ✓ Generated: ${countryPath}`);
+            }
+        }
+
+        console.log('\n✅ Club page regeneration complete!');
+
+    } catch (error) {
+        console.error('❌ Error:', error.message);
+        process.exit(1);
+    }
+}
+
+regenerateClubPages();


### PR DESCRIPTION
- Add regenerate-club-pages.js script to regenerate club and country pages
- Update GitHub Actions workflow to process club_ids and call the new script
- This ensures country pages have correct sticker counts when stickers move between clubs