### PR TITLE
Add lives system to TTR quiz mode

### DIFF
--- a/quiz.html
+++ b/quiz.html
@@ -109,7 +109,7 @@
              <div class="game-right-panel">
                  <div class="game-info">
                      <div id="timer">Time: <span id="time-left">10</span></div>
-                     <div id="lives" style="display: none;">Lives: <span id="lives-hearts"><span class="heart active">&#10084;</span><span class="heart active">&#10084;</span><span class="heart active">&#10084;</span></span></div>
+                     <div id="lives" style="display: none;">Lives: <span id="lives-hearts"><span class="heart active">&#10084;</span><span class="heart active">&#10084;</span><span class="heart active">&#10084;</span><span class="heart active">&#10084;</span><span class="heart active">&#10084;</span></span></div>
                      <div id="score">Score: <span id="current-score">0</span></div>
                  </div>
                  <div id="options" class="button-group options-group">


### PR DESCRIPTION
Додано систему життів до Time to Run режиму.

Що змінено:
1. TTR режим тепер має 5 життів-сердечок (замість відсутності життів)
2. Гра закінчується коли:
   - Вийшов час (60 секунд), АБО
   - Згоріли всі 5 життів

Деталі реалізації:
- Додано константу TTR_MAX_LIVES = 5
- Оновлено HTML: 5 сердечок замість 3
- resetLives() тепер приймає параметр maxLives і показує/приховує потрібну кількість сердечок
- startGame(): для TTR - resetLives(TTR_MAX_LIVES), для Classic - resetLives(MAX_LIVES)
- handleAnswerTTR():
  * При неправильній відповіді - await loseLife() з анімацією
  * Перевірка currentLives <= 0 перед продовженням
  * Якщо життя закінчилися - endGame()
- Додано паузи для відображення фідбеку (1 сек правильна, 2 сек неправильна)

Файли:
- quiz.html: 5 сердечок у розмітці
- script.js: логіка життів для TTR режиму