### PR TITLE
Add Daily Quiz mode with 18 stickers challenge

### DIFF
--- a/quiz.html
+++ b/quiz.html
@@ -73,6 +73,8 @@
         <div id="landing-page" style="display: none;">
             <button id="landing-play-easy-button" class="btn btn-primary btn-large">Play (easy level)</button>
             <button id="landing-ttr-button" class="btn btn-primary btn-large">Time To Run</button>
+            <button id="landing-daily-button" class="btn btn-primary btn-large">Daily Quiz</button>
+            <p class="daily-quiz-description">Guess all 18 stickers in 1 minute</p>
             <button id="landing-login-button" class="btn btn-secondary btn-large google-login">
                 <span>Sign in (middle & hard levels)</span>
             </button>
@@ -94,6 +96,10 @@
                 <div class="difficulty-option ttr-option">
                     <button id="ttr-mode-button" class="btn btn-primary btn-large">Time To Run</button>
                     <p class="difficulty-description">60 seconds for all difficulties</p>
+                </div>
+                <div class="difficulty-option daily-option">
+                    <button id="daily-mode-button" class="btn btn-primary btn-large">Daily Quiz</button>
+                    <p class="difficulty-description">Guess all 18 stickers in 1 minute</p>
                 </div>
             </div>
             <div class="leaderboard-action">

--- a/shared.js
+++ b/shared.js
@@ -19,11 +19,14 @@ const CONFIG = {
     // Game settings
     TIMER_DURATION: 10,
     TTR_TIMER_DURATION: 60,  // Time To Run mode: 60 seconds total
+    DAILY_TIMER_DURATION: 60,  // Daily Quiz mode: 60 seconds initial
+    DAILY_TOTAL_STICKERS: 18,  // Daily Quiz: 18 stickers to guess (3 sets of 6)
     LEADERBOARD_LIMIT: 10,
 
     // Game modes
     GAME_MODE_CLASSIC: 'classic',
     GAME_MODE_TTR: 'ttr',  // Time To Run mode
+    GAME_MODE_DAILY: 'daily',  // Daily Quiz mode
 
     // Nickname settings
     NICKNAME_MIN_LENGTH: 3,

--- a/style.css
+++ b/style.css
@@ -2319,23 +2319,23 @@ body.home-page #app-logo {
 }
 
 /* ------------------------------ */
-/* Time To Run Mode Styles        */
+/* Time To Run & Daily Quiz Mode Styles */
 /* ------------------------------ */
 
-/* TTR difficulty border colors on sticker container */
+/* TTR/Daily difficulty border colors on sticker container (3x thicker, 50% transparent) */
 #sticker-container.ttr-difficulty-1 {
-    border: 3px solid #28a745 !important; /* Green for Easy */
+    border: 9px solid rgba(40, 167, 69, 0.5) !important; /* Green for Easy - 50% transparent */
 }
 
 #sticker-container.ttr-difficulty-2 {
-    border: 3px solid #ffc107 !important; /* Yellow for Medium */
+    border: 9px solid rgba(255, 193, 7, 0.5) !important; /* Yellow for Medium - 50% transparent */
 }
 
 #sticker-container.ttr-difficulty-3 {
-    border: 3px solid #dc3545 !important; /* Red for Hard */
+    border: 9px solid rgba(220, 53, 69, 0.5) !important; /* Red for Hard - 50% transparent */
 }
 
-/* TTR timer flashing animation on last 10 seconds */
+/* TTR/Daily timer flashing animation on last 10 seconds */
 #time-left.ttr-flash {
     animation: ttr-timer-flash 0.5s ease-in-out infinite;
 }
@@ -2345,9 +2345,36 @@ body.home-page #app-logo {
     50% { color: var(--color-error); opacity: 0.4; }
 }
 
-/* TTR mode body indicator for potential styling */
-body.ttr-mode .game-info #timer {
+/* Time bonus flash animation (green flash when time is added in Daily mode) */
+#time-left.time-bonus-flash {
+    animation: time-bonus-flash 0.6s ease-out;
+}
+
+@keyframes time-bonus-flash {
+    0% { color: var(--color-success); transform: scale(1); }
+    30% { color: var(--color-success); transform: scale(1.3); }
+    60% { color: var(--color-success); transform: scale(1.1); }
+    100% { color: var(--color-text); transform: scale(1); }
+}
+
+/* TTR/Daily mode body indicator for potential styling */
+body.ttr-mode .game-info #timer,
+body.daily-mode .game-info #timer {
     color: var(--color-text);
+}
+
+/* Daily Quiz win message styling */
+#game-over-text.daily-win {
+    color: var(--color-success) !important;
+    font-size: 1.5em;
+}
+
+/* Daily Quiz description under button */
+.daily-quiz-description {
+    font-size: 0.85em;
+    color: var(--color-info-text);
+    margin: calc(var(--spacing-unit) * -0.5) 0 calc(var(--spacing-unit) * 1.5) 0;
+    padding: 0;
 }
 
 /* Leaderboard 4-column grid for TTR */


### PR DESCRIPTION
- Add Daily Quiz button to landing and difficulty selection pages
- Implement Daily Quiz game mode:
  - 60 seconds initial time with 18 stickers to guess
  - 3 sets of 6 stickers: 3 easy, 2 medium, 1 hard per set
  - Correct answers add bonus time: +1s easy, +2s medium, +3s hard
  - 5 lives, wrong answers cost 1 life (no time penalty)
  - Win condition: guess all 18 stickers
  - Loss conditions: run out of lives or time
- Add green timer flash animation for time bonus
- Update difficulty borders to 9px with 50% transparency for TTR and Daily modes
- Add "YOU WON!" green victory message for Daily Quiz winners