### PR TITLE
Fix sticker count to show 2857 (actual active stickers)

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
             </div>
             <div class="game-right-panel">
                 <div class="game-info">
-                    <div id="home-title">Football stickers. Total: <span id="total-stickers">2892</span></div>
+                    <div id="home-title">Football stickers. Total: <span id="total-stickers">2857</span></div>
                 </div>
                 <div id="options" class="button-group options-group">
                     <a href="/catalogue.html" class="btn">View Catalogue</a>

--- a/scripts/generate-static-pages.js
+++ b/scripts/generate-static-pages.js
@@ -712,8 +712,12 @@ async function generateIndexPage(stickers) {
     // First sticker for preload and initial display
     const firstSticker = stickerPool[0];
 
+    // Hardcoded sticker count (actual active sticker pages, excluding deleted/inactive)
+    // This should match the value in catalogue.js
+    const TOTAL_ACTIVE_STICKERS = 2857;
+
     const data = {
-        TOTAL_STICKERS: stickers.length,
+        TOTAL_STICKERS: TOTAL_ACTIVE_STICKERS,
         FIRST_STICKER_URL: firstSticker.url,
         FIRST_STICKER_LINK: `/stickers/${firstSticker.id}.html`,
         STICKER_POOL_JSON: JSON.stringify(stickerPool)


### PR DESCRIPTION
- Update index.html to display 2857 instead of 2892
- Update generate-static-pages.js to use hardcoded TOTAL_ACTIVE_STICKERS = 2857
- This matches the count in catalogue.js and reflects actual active sticker pages
- The count excludes deleted/inactive stickers from the database

Now both homepage and catalogue show the same correct count.

https://claude.ai/code/session_0121nqPtp28kqiJU49uGTdJJ