### PR TITLE
Add rating page with paginated sticker ratings

### DIFF
--- a/catalogue.js
+++ b/catalogue.js
@@ -392,31 +392,33 @@ async function loadMostRatedStickers() {
             return '';
         }
 
-        // Build HTML
+        // Build HTML in table format
         let html = '<div class="most-rated-section"><h3>Most rated stickers</h3>';
-        html += '<ul class="most-rated-list">';
+        html += '<table class="most-rated-table">';
+        html += '<tbody>';
 
         stickers.forEach((sticker, index) => {
             const clubName = sticker.clubs?.name || 'Unknown Club';
             const clubId = sticker.clubs?.id || null;
             const rating = sticker.rating || 1500;
 
-            let entry = `<span class="rank">${index + 1}.</span> `;
-            entry += `<a href="/stickers/${sticker.id}.html" class="sticker-link">${sticker.id}</a>, `;
-
+            html += '<tr>';
+            html += `<td class="rank-cell">${index + 1}.</td>`;
+            html += `<td class="sticker-cell"><a href="/stickers/${sticker.id}.html">${sticker.id}</a></td>`;
+            html += '<td class="club-cell">';
             if (clubId) {
-                entry += `<a href="/clubs/${clubId}.html" class="club-link">${clubName}</a>`;
+                html += `<a href="/clubs/${clubId}.html">${clubName}</a>`;
             } else {
-                entry += clubName;
+                html += clubName;
             }
-
-            entry += ` <span class="rating-badge">${rating}</span>`;
-
-            html += `<li>${entry}</li>`;
+            html += '</td>';
+            html += `<td class="rating-cell">${rating}</td>`;
+            html += '</tr>';
         });
 
-        html += '</ul>';
-        html += '<a href="/battle.html" class="rate-stickers-link">Rate stickers</a>';
+        html += '</tbody>';
+        html += '</table>';
+        html += '<a href="/rating.html" class="view-full-rating-link">View full rating</a>';
         html += '</div>';
 
         return html;

--- a/index.html
+++ b/index.html
@@ -104,9 +104,9 @@
                     <div id="home-title">Football stickers. Total: <span id="total-stickers">2857</span></div>
                 </div>
                 <div id="options" class="button-group options-group">
-                    <a href="/catalogue.html" class="btn">View Catalogue</a>
-                    <a href="/map.html" class="btn">View Map</a>
-                    <a href="/battle.html" class="btn">Rate Stickers</a>
+                    <a href="/catalogue.html" class="btn">Catalogue</a>
+                    <a href="/map.html" class="btn">Map</a>
+                    <a href="/rating.html" class="btn">Rating</a>
                     <a href="/quiz.html" class="btn">Play Quiz</a>
                     <button id="home-auth-button" class="btn">Sign In</button>
                 </div>

--- a/rating.html
+++ b/rating.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sticker Rating - StickerHunt</title>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
+    <!-- SEO Meta Tags -->
+    <meta name="description" content="View the full rating of football stickers based on community votes. Discover the most popular stickers in our collection.">
+    <meta name="keywords" content="football stickers, sticker rating, top stickers, best stickers, sticker ranking">
+    <link rel="canonical" href="https://stickerhunt.club/rating.html">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://stickerhunt.club/rating.html">
+    <meta property="og:title" content="Sticker Rating - StickerHunt">
+    <meta property="og:description" content="View the full rating of football stickers based on community votes.">
+    <meta property="og:image" content="https://stickerhunt.club/metash.png">
+    <meta property="og:site_name" content="StickerHunt">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://stickerhunt.club/rating.html">
+    <meta property="twitter:title" content="Sticker Rating - StickerHunt">
+    <meta property="twitter:description" content="View the full rating of football stickers based on community votes.">
+    <meta property="twitter:image" content="https://stickerhunt.club/metash.png">
+    <meta property="twitter:site" content="@StickerHunting">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="/style.css">
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4Y0MJKGDZS"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-4Y0MJKGDZS');
+    </script>
+
+    <!-- Amplitude Analytics -->
+    <script src="https://cdn.amplitude.com/script/678e88d5fa8972f1fe39b2cd59ef456.js"></script>
+    <script>window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));window.amplitude.init('678e88d5fa8972f1fe39b2cd59ef456', {"fetchRemoteConfig":true,"autocapture":{"attribution":true,"fileDownloads":true,"formInteractions":true,"pageViews":true,"sessions":true,"elementInteractions":true,"networkTracking":true,"webVitals":true,"frustrationInteractions":true}});</script>
+</head>
+<body>
+    <header class="app-header">
+        <div class="logo-container">
+           <a href="/index.html"><img src="/logo.png" alt="StickerHunt Logo" id="app-logo"></a>
+        </div>
+        <div id="auth-section">
+             <button id="login-button" class="btn btn-primary google-login" style="display: none;">
+                 <span>Sign in with Google</span>
+             </button>
+             <div id="user-status" style="display: none;">
+                 <strong id="user-nickname" title="Click to edit nickname">Loading...</strong>
+                 <button id="logout-button" class="btn-link">Logout</button>
+                 <form id="edit-nickname-form" style="display: none;">
+                     <input type="text" id="nickname-input" placeholder="Enter new nickname" required minlength="3" maxlength="25" size="15">
+                     <button type="submit" class="btn btn-primary">Save</button>
+                     <button type="button" id="cancel-edit-nickname-button" class="btn btn-secondary">Cancel</button>
+                 </form>
+             </div>
+         </div>
+    </header>
+
+    <main class="container" id="rating-container">
+        <h1>Sticker Rating</h1>
+
+        <!-- Rate Stickers button at top -->
+        <div class="rating-actions-top">
+            <a href="/battle.html" class="btn btn-primary">Rate stickers</a>
+        </div>
+
+        <!-- Rating content will be loaded here -->
+        <div id="rating-content">
+            <p>Loading ratings...</p>
+        </div>
+
+        <!-- Pagination -->
+        <div id="rating-pagination" style="display: none;"></div>
+
+        <!-- Rate Stickers button at bottom -->
+        <div class="rating-actions-bottom">
+            <a href="/battle.html" class="btn btn-primary">Rate stickers</a>
+        </div>
+    </main>
+
+    <footer class="app-footer">
+        <p>
+            <a href="/about.html">About</a> |
+            <a href="/terms.html">Terms of Service</a> |
+            <a href="/privacy.html">Privacy Policy</a>
+        </p>
+        <p>StickerHunt &copy; 2025</p>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script src="/shared.js"></script>
+    <script src="/rating.js"></script>
+</body>
+</html>

--- a/rating.js
+++ b/rating.js
@@ -1,0 +1,461 @@
+// rating.js - Rating page functionality
+
+let supabaseClient;
+let currentPage = 1;
+let totalStickers = 0;
+const STICKERS_PER_PAGE_MOBILE = 100;
+const STICKERS_PER_PAGE_DESKTOP = 200;
+
+// Auth state
+let currentUser = null;
+let currentUserProfile = null;
+
+// Edit nickname form elements
+let editNicknameForm;
+let nicknameInputElement;
+let cancelEditNicknameButton;
+
+// Initialize Supabase Client
+if (typeof SharedUtils === 'undefined') {
+    console.error('Error: SharedUtils not loaded. Make sure shared.js is included before rating.js');
+    const contentDiv = document.getElementById('rating-content');
+    if (contentDiv) {
+        contentDiv.innerHTML = "<p>Initialization error. Rating cannot be loaded.</p>";
+    }
+} else {
+    supabaseClient = SharedUtils.initSupabaseClient();
+}
+
+// Detect if desktop (2 columns) or mobile (1 column)
+function isDesktop() {
+    return window.innerWidth >= 900;
+}
+
+// Get stickers per page based on screen size
+function getStickersPerPage() {
+    return isDesktop() ? STICKERS_PER_PAGE_DESKTOP : STICKERS_PER_PAGE_MOBILE;
+}
+
+// Get columns count based on screen size
+function getColumnsCount() {
+    return isDesktop() ? 2 : 1;
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+    if (supabaseClient) {
+        // Setup auth
+        setupAuth();
+
+        // Initialize nickname editing elements
+        editNicknameForm = document.getElementById('edit-nickname-form');
+        nicknameInputElement = document.getElementById('nickname-input');
+        cancelEditNicknameButton = document.getElementById('cancel-edit-nickname-button');
+        setupNicknameEditing();
+
+        // Get page from URL query parameter
+        const urlParams = new URLSearchParams(window.location.search);
+        const pageParam = urlParams.get('page');
+        if (pageParam && !isNaN(pageParam) && parseInt(pageParam) > 0) {
+            currentPage = parseInt(pageParam);
+        }
+
+        await loadRatingData();
+
+        // Reload on window resize to adjust columns
+        let resizeTimer;
+        window.addEventListener('resize', () => {
+            clearTimeout(resizeTimer);
+            resizeTimer = setTimeout(() => {
+                loadRatingData();
+            }, 250);
+        });
+    } else {
+        console.error('Supabase client failed to initialize.');
+        const contentDiv = document.getElementById('rating-content');
+        if (contentDiv) contentDiv.innerHTML = "<p>Initialization error. Rating cannot be loaded.</p>";
+    }
+});
+
+async function loadRatingData() {
+    const contentDiv = document.getElementById('rating-content');
+    const paginationDiv = document.getElementById('rating-pagination');
+
+    contentDiv.innerHTML = '<p>Loading ratings...</p>';
+    paginationDiv.style.display = 'none';
+
+    if (!supabaseClient) {
+        contentDiv.innerHTML = '<p>Error: Cannot load ratings.</p>';
+        return;
+    }
+
+    try {
+        // Get total count of stickers
+        const { count, error: countError } = await supabaseClient
+            .from('stickers')
+            .select('*', { count: 'exact', head: true });
+
+        if (countError) {
+            console.error('Error fetching sticker count:', countError);
+            contentDiv.innerHTML = `<p>Could not load ratings: ${countError.message}</p>`;
+            return;
+        }
+
+        totalStickers = count || 0;
+        const stickersPerPage = getStickersPerPage();
+        const totalPages = Math.ceil(totalStickers / stickersPerPage);
+
+        // Ensure current page is valid
+        if (currentPage > totalPages) {
+            currentPage = totalPages;
+        }
+        if (currentPage < 1) {
+            currentPage = 1;
+        }
+
+        const offset = (currentPage - 1) * stickersPerPage;
+
+        // Fetch stickers for current page
+        const { data: stickers, error: stickersError } = await supabaseClient
+            .from('stickers')
+            .select(`
+                id,
+                rating,
+                clubs (
+                    id,
+                    name,
+                    country
+                )
+            `)
+            .order('rating', { ascending: false })
+            .range(offset, offset + stickersPerPage - 1);
+
+        if (stickersError) {
+            console.error('Error fetching stickers:', stickersError);
+            contentDiv.innerHTML = `<p>Could not load ratings: ${stickersError.message}</p>`;
+            return;
+        }
+
+        if (!stickers || stickers.length === 0) {
+            contentDiv.innerHTML = '<p>No stickers found.</p>';
+            return;
+        }
+
+        // Build rating table HTML
+        const columnsCount = getColumnsCount();
+        const stickersPerColumn = Math.ceil(stickers.length / columnsCount);
+
+        let html = '<div class="rating-table-container">';
+
+        // Create columns
+        for (let col = 0; col < columnsCount; col++) {
+            const startIdx = col * stickersPerColumn;
+            const endIdx = Math.min(startIdx + stickersPerColumn, stickers.length);
+            const columnStickers = stickers.slice(startIdx, endIdx);
+
+            if (columnStickers.length === 0) continue;
+
+            html += '<div class="rating-column">';
+            html += '<table class="rating-table">';
+            html += '<tbody>';
+
+            columnStickers.forEach((sticker, idx) => {
+                const globalRank = offset + startIdx + idx + 1;
+                const clubName = sticker.clubs?.name || 'Unknown Club';
+                const clubId = sticker.clubs?.id || null;
+                const rating = sticker.rating || 1500;
+
+                html += '<tr>';
+                html += `<td class="rank-cell">${globalRank}.</td>`;
+                html += `<td class="sticker-cell"><a href="/stickers/${sticker.id}.html">${sticker.id}</a></td>`;
+                html += '<td class="club-cell">';
+                if (clubId) {
+                    html += `<a href="/clubs/${clubId}.html">${clubName}</a>`;
+                } else {
+                    html += clubName;
+                }
+                html += '</td>';
+                html += `<td class="rating-cell">${rating}</td>`;
+                html += '</tr>';
+            });
+
+            html += '</tbody>';
+            html += '</table>';
+            html += '</div>';
+        }
+
+        html += '</div>';
+
+        contentDiv.innerHTML = html;
+
+        // Build pagination
+        if (totalPages > 1) {
+            renderPagination(totalPages);
+            paginationDiv.style.display = 'block';
+        }
+    } catch (error) {
+        console.error('An error occurred while loading ratings:', error);
+        contentDiv.innerHTML = `<p>An unexpected error occurred: ${error.message}</p>`;
+    }
+}
+
+function renderPagination(totalPages) {
+    const paginationDiv = document.getElementById('rating-pagination');
+    let html = '<div class="pagination">';
+
+    // Previous button
+    if (currentPage > 1) {
+        html += `<a href="?page=${currentPage - 1}" class="pagination-btn" onclick="goToPage(${currentPage - 1}); return false;">← Previous</a>`;
+    } else {
+        html += '<span class="pagination-btn disabled">← Previous</span>';
+    }
+
+    // Page numbers
+    html += '<span class="pagination-info">Page ' + currentPage + ' of ' + totalPages + '</span>';
+
+    // Next button
+    if (currentPage < totalPages) {
+        html += `<a href="?page=${currentPage + 1}" class="pagination-btn" onclick="goToPage(${currentPage + 1}); return false;">Next →</a>`;
+    } else {
+        html += '<span class="pagination-btn disabled">Next →</span>';
+    }
+
+    html += '</div>';
+    paginationDiv.innerHTML = html;
+}
+
+function goToPage(page) {
+    currentPage = page;
+    window.scrollTo(0, 0);
+    loadRatingData();
+
+    // Update URL without reloading page
+    const newUrl = window.location.pathname + '?page=' + page;
+    window.history.pushState({page: page}, '', newUrl);
+}
+
+// Handle browser back/forward buttons
+window.addEventListener('popstate', (event) => {
+    if (event.state && event.state.page) {
+        currentPage = event.state.page;
+    } else {
+        const urlParams = new URLSearchParams(window.location.search);
+        const pageParam = urlParams.get('page');
+        currentPage = pageParam && !isNaN(pageParam) ? parseInt(pageParam) : 1;
+    }
+    loadRatingData();
+});
+
+// ========== AUTH FUNCTIONS ==========
+
+// Load user profile
+async function loadAndSetUserProfile(user) {
+    if (!supabaseClient || !user) return;
+
+    const profile = await SharedUtils.loadUserProfile(supabaseClient, user);
+    if (profile) {
+        currentUserProfile = profile;
+        SharedUtils.cacheUserProfile(profile);
+    }
+}
+
+// Update auth UI
+function updateAuthUI(user) {
+    const loginButton = document.getElementById('login-button');
+    const userStatusElement = document.getElementById('user-status');
+    const userNicknameElement = document.getElementById('user-nickname');
+
+    if (!loginButton || !userStatusElement || !userNicknameElement) return;
+
+    if (user) {
+        const displayName = currentUserProfile?.username || 'Loading...';
+        userNicknameElement.textContent = SharedUtils.truncateString(displayName);
+        loginButton.style.display = 'none';
+        userStatusElement.style.display = 'flex';
+    } else {
+        loginButton.style.display = 'none';
+        userStatusElement.style.display = 'none';
+    }
+}
+
+// Login with Google
+function handleLoginClick() {
+    if (!supabaseClient) return;
+    SharedUtils.loginWithGoogle(supabaseClient, '/rating.html').then(result => {
+        if (result.error) {
+            alert('Login failed. Please try again.');
+        }
+    });
+}
+
+// Logout
+async function handleLogoutClick() {
+    if (!supabaseClient) {
+        console.error('Logout failed: supabaseClient is null');
+        return;
+    }
+
+    try {
+        const result = await SharedUtils.logout(supabaseClient, currentUser?.id);
+        if (result.error) {
+            alert('Logout failed. Please try again.');
+        } else {
+            window.location.reload();
+        }
+    } catch (err) {
+        console.error('Logout exception:', err);
+        alert('Logout error: ' + err.message);
+    }
+}
+
+function setupAuth() {
+    if (!supabaseClient) return;
+
+    const loginButton = document.getElementById('login-button');
+    const logoutButton = document.getElementById('logout-button');
+
+    if (loginButton) {
+        loginButton.addEventListener('click', handleLoginClick);
+    }
+    if (logoutButton) {
+        logoutButton.addEventListener('click', handleLogoutClick);
+    }
+
+    supabaseClient.auth.getSession().then(async ({ data: { session }, error }) => {
+        if (error) {
+            console.error('Error getting session:', error);
+            updateAuthUI(null);
+            setupAuthStateListener();
+            return;
+        }
+
+        const user = session?.user ?? null;
+
+        if (user) {
+            currentUser = user;
+
+            const cachedProfile = SharedUtils.loadCachedProfile(user.id);
+            if (cachedProfile) {
+                currentUserProfile = cachedProfile;
+                updateAuthUI(user);
+            }
+
+            await loadAndSetUserProfile(user);
+            SharedUtils.identifyAmplitudeUser(user, currentUserProfile);
+            updateAuthUI(user);
+        } else {
+            updateAuthUI(null);
+        }
+
+        setupAuthStateListener();
+    });
+}
+
+function setupAuthStateListener() {
+    if (!supabaseClient) return;
+
+    supabaseClient.auth.onAuthStateChange(async (event, session) => {
+        if (event === 'INITIAL_SESSION') {
+            return;
+        }
+
+        const user = session?.user ?? null;
+
+        if (event === 'SIGNED_OUT') {
+            if (currentUser) {
+                SharedUtils.clearCachedProfile(currentUser.id);
+            }
+            currentUser = null;
+            currentUserProfile = null;
+            SharedUtils.clearAmplitudeUser();
+            updateAuthUI(null);
+            return;
+        }
+
+        if (event === 'SIGNED_IN' && user) {
+            if (!currentUser || currentUser.id !== user.id) {
+                currentUser = user;
+                const cachedProfile = SharedUtils.loadCachedProfile(user.id);
+                if (cachedProfile) {
+                    currentUserProfile = cachedProfile;
+                }
+                updateAuthUI(user);
+                await loadAndSetUserProfile(user);
+                SharedUtils.identifyAmplitudeUser(user, currentUserProfile);
+                updateAuthUI(user);
+            }
+        }
+
+        if (event === 'TOKEN_REFRESHED' && user) {
+            currentUser = user;
+        }
+    });
+}
+
+// ========== NICKNAME EDITING FUNCTIONS ==========
+
+function setupNicknameEditing() {
+    const userNicknameElement = document.getElementById('user-nickname');
+    if (!userNicknameElement) return;
+
+    userNicknameElement.addEventListener('click', showNicknameEditForm);
+
+    if (editNicknameForm) {
+        editNicknameForm.addEventListener('submit', handleNicknameSave);
+    }
+    if (cancelEditNicknameButton) {
+        cancelEditNicknameButton.addEventListener('click', hideNicknameEditForm);
+    }
+}
+
+function showNicknameEditForm() {
+    if (!currentUserProfile) {
+        alert('Please wait for your profile to load...');
+        return;
+    }
+
+    if (!editNicknameForm || !nicknameInputElement) return;
+
+    nicknameInputElement.value = currentUserProfile.username || '';
+    editNicknameForm.style.display = 'block';
+    nicknameInputElement.focus();
+    nicknameInputElement.select();
+}
+
+function hideNicknameEditForm() {
+    if (!editNicknameForm || !nicknameInputElement) return;
+    editNicknameForm.style.display = 'none';
+    nicknameInputElement.value = '';
+}
+
+async function handleNicknameSave(event) {
+    event.preventDefault();
+
+    if (!currentUser || !nicknameInputElement || !supabaseClient || !currentUserProfile) {
+        alert('Cannot save nickname');
+        return;
+    }
+
+    const newNickname = nicknameInputElement.value.trim();
+
+    if (newNickname === currentUserProfile.username) {
+        hideNicknameEditForm();
+        return;
+    }
+
+    const result = await SharedUtils.updateNickname(supabaseClient, currentUser.id, newNickname);
+
+    if (result.error) {
+        alert(`Update failed: ${result.error.message}`);
+    } else {
+        currentUserProfile.username = result.data.username;
+        SharedUtils.cacheUserProfile(currentUserProfile);
+
+        const userNicknameElement = document.getElementById('user-nickname');
+        if (userNicknameElement) {
+            userNicknameElement.textContent = SharedUtils.truncateString(result.data.username);
+        }
+
+        hideNicknameEditForm();
+        alert('Nickname updated successfully!');
+    }
+}

--- a/style.css
+++ b/style.css
@@ -1791,33 +1791,76 @@ body.home-page #home-title #total-stickers {
     border-bottom: 1px dashed var(--color-border);
 }
 
-.most-rated-list {
-    list-style: none;
-    padding-left: 0;
+/* Most rated table */
+.most-rated-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    text-align: left;
+    font-size: 1em;
 }
 
-.most-rated-list li {
-    margin-bottom: var(--spacing-unit);
-    font-size: 1.1em;
+.most-rated-table tbody tr {
+    border-bottom: 1px solid var(--color-border);
+    transition: background-color 0.2s ease;
 }
 
-.most-rated-list .rank {
+.most-rated-table tbody tr:last-child {
+    border-bottom: none;
+}
+
+.most-rated-table td {
+    padding: calc(var(--spacing-unit) * 1) calc(var(--spacing-unit) * 0.75);
+    vertical-align: middle;
+}
+
+.most-rated-table .rank-cell {
     color: var(--color-rank);
     font-weight: 600;
-    min-width: 2em;
-    display: inline-block;
+    text-align: right;
+    min-width: 2.5em;
+    white-space: nowrap;
 }
 
-.most-rated-list .sticker-link,
-.most-rated-list .club-link {
+.most-rated-table .sticker-cell {
+    text-align: left;
+    min-width: 4em;
+    white-space: nowrap;
+}
+
+.most-rated-table .sticker-cell a {
     color: var(--color-info-text);
     text-decoration: none;
     font-weight: 500;
 }
 
+.most-rated-table .club-cell {
+    text-align: left;
+    width: 100%;
+    padding-right: calc(var(--spacing-unit) * 1);
+}
+
+.most-rated-table .club-cell a {
+    color: var(--color-info-text);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.most-rated-table .rating-cell {
+    text-align: right;
+    font-weight: 600;
+    color: var(--color-accent-darker);
+    min-width: 4em;
+    white-space: nowrap;
+}
+
 @media (hover: hover) {
-    .most-rated-list .sticker-link:hover,
-    .most-rated-list .club-link:hover {
+    .most-rated-table tbody tr:hover {
+        background-color: var(--color-secondary-bg-hover);
+    }
+
+    .most-rated-table .sticker-cell a:hover,
+    .most-rated-table .club-cell a:hover {
         color: var(--color-link);
         text-decoration: underline;
     }
@@ -1834,7 +1877,8 @@ body.home-page #home-title #total-stickers {
     margin-left: 4px;
 }
 
-.rate-stickers-link {
+.rate-stickers-link,
+.view-full-rating-link {
     display: inline-block;
     margin-top: calc(var(--spacing-unit) * 1.5);
     color: var(--color-info-text);
@@ -1844,7 +1888,8 @@ body.home-page #home-title #total-stickers {
 }
 
 @media (hover: hover) {
-    .rate-stickers-link:hover {
+    .rate-stickers-link:hover,
+    .view-full-rating-link:hover {
         color: var(--color-link);
         text-decoration: underline;
     }
@@ -3154,5 +3199,227 @@ body.daily-mode .game-info #timer {
     .battle-actions .btn {
         width: 100%;
         max-width: 280px;
+    }
+}
+
+/* ------------------------------ */
+/* Rating Page Styles             */
+/* ------------------------------ */
+
+#rating-container {
+    max-width: 1200px;
+    text-align: center;
+}
+
+#rating-container h1 {
+    margin-bottom: calc(var(--spacing-unit) * 3);
+}
+
+/* Rate Stickers buttons at top and bottom */
+.rating-actions-top,
+.rating-actions-bottom {
+    margin: calc(var(--spacing-unit) * 3) auto;
+    text-align: center;
+}
+
+.rating-actions-top {
+    margin-top: 0;
+}
+
+.rating-actions-bottom {
+    margin-bottom: calc(var(--spacing-unit) * 2);
+}
+
+/* Rating table container - holds columns */
+.rating-table-container {
+    display: flex;
+    gap: calc(var(--spacing-unit) * 4);
+    justify-content: center;
+    align-items: flex-start;
+    margin: calc(var(--spacing-unit) * 3) auto;
+    flex-wrap: wrap;
+}
+
+/* Individual rating column */
+.rating-column {
+    flex: 1;
+    min-width: 400px;
+    max-width: 550px;
+}
+
+/* Rating table */
+.rating-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    text-align: left;
+    font-size: 1em;
+}
+
+.rating-table tbody tr {
+    border-bottom: 1px solid var(--color-border);
+    transition: background-color 0.2s ease;
+}
+
+.rating-table tbody tr:last-child {
+    border-bottom: none;
+}
+
+/* Table cells */
+.rating-table td {
+    padding: calc(var(--spacing-unit) * 1.25) calc(var(--spacing-unit) * 0.75);
+    vertical-align: middle;
+}
+
+/* Rank cell */
+.rank-cell {
+    color: var(--color-rank);
+    font-weight: 600;
+    text-align: right;
+    min-width: 3em;
+    white-space: nowrap;
+}
+
+/* Sticker ID cell */
+.sticker-cell {
+    text-align: left;
+    min-width: 4em;
+    white-space: nowrap;
+}
+
+.sticker-cell a {
+    color: var(--color-info-text);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+/* Club name cell - takes remaining space */
+.club-cell {
+    text-align: left;
+    width: 100%;
+    padding-right: calc(var(--spacing-unit) * 1);
+}
+
+.club-cell a {
+    color: var(--color-info-text);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+/* Rating cell */
+.rating-cell {
+    text-align: right;
+    font-weight: 600;
+    color: var(--color-accent-darker);
+    min-width: 4em;
+    white-space: nowrap;
+}
+
+/* Hover effects */
+@media (hover: hover) {
+    .rating-table tbody tr:hover {
+        background-color: var(--color-secondary-bg-hover);
+    }
+
+    .sticker-cell a:hover,
+    .club-cell a:hover {
+        color: var(--color-link);
+        text-decoration: underline;
+    }
+}
+
+/* Pagination */
+#rating-pagination {
+    margin: calc(var(--spacing-unit) * 4) auto calc(var(--spacing-unit) * 2) auto;
+    text-align: center;
+}
+
+.pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: calc(var(--spacing-unit) * 2);
+    flex-wrap: wrap;
+}
+
+.pagination-btn {
+    display: inline-block;
+    padding: calc(var(--spacing-unit) * 1) calc(var(--spacing-unit) * 2);
+    background-color: var(--color-background);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+    text-decoration: none;
+    font-weight: 500;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.pagination-btn:not(.disabled):hover {
+    background-color: var(--color-accent);
+    border-color: var(--color-accent);
+    color: var(--color-accent-text);
+}
+
+.pagination-btn.disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+.pagination-info {
+    font-weight: 500;
+    color: var(--color-info-text);
+}
+
+/* Responsive: Mobile */
+@media (max-width: 900px) {
+    .rating-table-container {
+        flex-direction: column;
+        gap: 0;
+    }
+
+    .rating-column {
+        width: 100%;
+        min-width: unset;
+        max-width: 100%;
+    }
+
+    .rating-table {
+        font-size: 0.95em;
+    }
+
+    .rating-table td {
+        padding: calc(var(--spacing-unit) * 1) calc(var(--spacing-unit) * 0.5);
+    }
+
+    .rank-cell {
+        min-width: 2.5em;
+    }
+
+    .sticker-cell {
+        min-width: 3em;
+    }
+
+    .rating-cell {
+        min-width: 3.5em;
+    }
+}
+
+@media (max-width: 500px) {
+    .rating-table {
+        font-size: 0.9em;
+    }
+
+    .rating-table td {
+        padding: calc(var(--spacing-unit) * 0.75) calc(var(--spacing-unit) * 0.4);
+    }
+
+    .pagination {
+        gap: calc(var(--spacing-unit) * 1);
+    }
+
+    .pagination-btn {
+        padding: calc(var(--spacing-unit) * 0.75) calc(var(--spacing-unit) * 1.5);
+        font-size: 0.9em;
     }
 }


### PR DESCRIPTION
- Create new rating.html page with dynamic rating list
- Update homepage buttons: "Rate Stickers" → "Rating", "View Catalogue" → "Catalogue", "View Map" → "Map"
- Update catalogue page "Most rated stickers" section to use table format
- Change catalogue link to "View full rating" pointing to rating.html
- Add pagination for rating page (100 stickers per page on mobile, 200 on desktop with 2 columns)
- Rating table shows: rank, sticker number, club name, rating
- Add "Rate stickers" buttons at top and bottom of rating page linking to battle.html

https://claude.ai/code/session_gcKmp