### PR TITLE
Improve rating page and UI consistency

### DIFF
--- a/battle.html
+++ b/battle.html
@@ -121,8 +121,10 @@
 
             <!-- Navigation buttons -->
             <div class="battle-actions">
-                <a href="/quiz.html" class="btn btn-primary">Play Quiz</a>
-                <a href="/catalogue.html" class="btn btn-nav">View Catalogue</a>
+                <a href="/catalogue.html" class="btn btn-nav">Catalogue</a>
+                <a href="/map.html" class="btn btn-nav">Map</a>
+                <a href="/rating.html" class="btn btn-nav">Rating</a>
+                <a href="/quiz.html" class="btn btn-nav">Play Quiz</a>
             </div>
         </div>
     </main>

--- a/catalogue.js
+++ b/catalogue.js
@@ -78,6 +78,13 @@ function updateMetaDescription(description) {
     }
 }
 
+// Truncate long text to max length
+function truncateText(text, maxLength = 25) {
+    if (!text) return '';
+    if (text.length <= maxLength) return text;
+    return text.substring(0, maxLength) + '...';
+}
+
 const countryCodeToDetails_Generic = {
     "AFG": { name: "Afghanistan", continent: "Asia" },
     "ALB": { name: "Albania", continent: "Europe" },
@@ -338,14 +345,15 @@ async function loadLastStickers() {
 
             groupedByDate[date].forEach(sticker => {
                 const clubName = sticker.clubs?.name || 'Unknown Club';
+                const clubNameDisplay = truncateText(clubName, 25);
                 const clubId = sticker.clubs?.id || null;
 
                 let entry = '<a href="/stickers/' + sticker.id + '.html" class="sticker-link">' + sticker.id + '</a>, ';
 
                 if (clubId) {
-                    entry += '<a href="/clubs/' + clubId + '.html" class="club-link">' + clubName + '</a>';
+                    entry += '<a href="/clubs/' + clubId + '.html" class="club-link" title="' + clubName + '">' + clubNameDisplay + '</a>';
                 } else {
-                    entry += clubName;
+                    entry += '<span title="' + clubName + '">' + clubNameDisplay + '</span>';
                 }
 
                 entry += '.';
@@ -399,6 +407,7 @@ async function loadMostRatedStickers() {
 
         stickers.forEach((sticker, index) => {
             const clubName = sticker.clubs?.name || 'Unknown Club';
+            const clubNameDisplay = truncateText(clubName, 25);
             const clubId = sticker.clubs?.id || null;
             const rating = sticker.rating || 1500;
 
@@ -407,9 +416,9 @@ async function loadMostRatedStickers() {
             html += `<td class="sticker-cell"><a href="/stickers/${sticker.id}.html">${sticker.id}</a></td>`;
             html += '<td class="club-cell">';
             if (clubId) {
-                html += `<a href="/clubs/${clubId}.html">${clubName}</a>`;
+                html += `<a href="/clubs/${clubId}.html" title="${clubName}">${clubNameDisplay}</a>`;
             } else {
-                html += clubName;
+                html += `<span title="${clubName}">${clubNameDisplay}</span>`;
             }
             html += '</td>';
             html += `<td class="rating-cell">${rating}</td>`;

--- a/rating.js
+++ b/rating.js
@@ -41,6 +41,13 @@ function getColumnsCount() {
     return isDesktop() ? 2 : 1;
 }
 
+// Truncate long text to max length
+function truncateText(text, maxLength = 25) {
+    if (!text) return '';
+    if (text.length <= maxLength) return text;
+    return text.substring(0, maxLength) + '...';
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
     if (supabaseClient) {
         // Setup auth
@@ -161,6 +168,7 @@ async function loadRatingData() {
             columnStickers.forEach((sticker, idx) => {
                 const globalRank = offset + startIdx + idx + 1;
                 const clubName = sticker.clubs?.name || 'Unknown Club';
+                const clubNameDisplay = truncateText(clubName, 25);
                 const clubId = sticker.clubs?.id || null;
                 const rating = sticker.rating || 1500;
 
@@ -169,9 +177,9 @@ async function loadRatingData() {
                 html += `<td class="sticker-cell"><a href="/stickers/${sticker.id}.html">${sticker.id}</a></td>`;
                 html += '<td class="club-cell">';
                 if (clubId) {
-                    html += `<a href="/clubs/${clubId}.html">${clubName}</a>`;
+                    html += `<a href="/clubs/${clubId}.html" title="${clubName}">${clubNameDisplay}</a>`;
                 } else {
-                    html += clubName;
+                    html += `<span title="${clubName}">${clubNameDisplay}</span>`;
                 }
                 html += '</td>';
                 html += `<td class="rating-cell">${rating}</td>`;

--- a/style.css
+++ b/style.css
@@ -656,6 +656,12 @@ body.quiz-result .result-right-panel {
         flex: 1;
         display: flex;
         flex-direction: column;
+        min-height: 0;
+    }
+
+    .catalogue-stickers-row .last-stickers-section > *:last-child,
+    .catalogue-stickers-row .most-rated-section > *:last-child {
+        margin-top: auto;
     }
 
     /* Countries grid: two columns */
@@ -3181,12 +3187,34 @@ body.daily-mode .game-info #timer {
 .battle-actions {
     display: flex;
     justify-content: center;
-    gap: calc(var(--spacing-unit) * 2);
+    gap: calc(var(--spacing-unit) * 1.5);
     margin-top: calc(var(--spacing-unit) * 4);
+    flex-wrap: wrap;
 }
 
 .battle-actions .btn {
-    min-width: 160px;
+    min-width: 140px;
+    background-color: var(--color-background);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+}
+
+.battle-actions .btn:hover {
+    background-color: var(--color-accent);
+    color: var(--color-accent-text);
+    border-color: var(--color-accent);
+}
+
+@media (max-width: 650px) {
+    .battle-actions {
+        gap: calc(var(--spacing-unit) * 1);
+    }
+
+    .battle-actions .btn {
+        min-width: 120px;
+        font-size: 0.95em;
+        padding: calc(var(--spacing-unit) * 1.2) calc(var(--spacing-unit) * 1.5);
+    }
 }
 
 @media (max-width: 500px) {
@@ -3199,6 +3227,7 @@ body.daily-mode .game-info #timer {
     .battle-actions .btn {
         width: 100%;
         max-width: 280px;
+        min-width: unset;
     }
 }
 


### PR DESCRIPTION
- Truncate long club names to 25 characters max (with ... suffix) in rating page and catalogue sections
- Add title attribute to show full club name on hover
- Update battle.html to show 4 navigation buttons horizontally: Catalogue, Map, Rating, Play Quiz
- Style battle buttons with white background and yellow hover effect
- Improve catalogue sections layout to ensure equal heights for Last stickers and Most rated blocks
- Add responsive wrapping for battle buttons on smaller screens

https://claude.ai/code/session_gcKmp