### PR TITLE
Make catalogue sections consistent and prevent line wrapping

### DIFF
--- a/catalogue.js
+++ b/catalogue.js
@@ -316,54 +316,42 @@ async function loadLastStickers() {
             return '';
         }
 
-        // Group stickers by date
-        const groupedByDate = {};
-        stickers.forEach(sticker => {
-            if (!sticker.created_at) return;
-            const dateKey = new Date(sticker.created_at).toISOString().split('T')[0];
-            if (!groupedByDate[dateKey]) {
-                groupedByDate[dateKey] = [];
-            }
-            groupedByDate[dateKey].push(sticker);
-        });
-
-        // Build HTML
+        // Build HTML in table format (same as Most rated)
         let html = '<div class="last-stickers-section"><h3>Last stickers</h3>';
+        html += '<table class="last-stickers-table">';
+        html += '<tbody>';
 
-        const sortedDates = Object.keys(groupedByDate).sort((a, b) => b.localeCompare(a));
+        stickers.forEach((sticker, index) => {
+            const clubName = sticker.clubs?.name || 'Unknown Club';
+            const clubNameDisplay = truncateText(clubName, 25);
+            const clubId = sticker.clubs?.id || null;
 
-        sortedDates.forEach(date => {
-            const dateObj = new Date(date);
-            const formattedDate = dateObj.toLocaleDateString('en-GB', {
-                day: 'numeric',
-                month: 'long',
-                year: 'numeric'
-            });
+            // Format date
+            let dateDisplay = '';
+            if (sticker.created_at) {
+                const dateObj = new Date(sticker.created_at);
+                dateDisplay = dateObj.toLocaleDateString('en-GB', {
+                    day: 'numeric',
+                    month: 'short'
+                });
+            }
 
-            html += `<div class="last-stickers-date-header"><strong>${formattedDate}</strong></div>`;
-            html += '<ul class="last-stickers-list">';
-
-            groupedByDate[date].forEach(sticker => {
-                const clubName = sticker.clubs?.name || 'Unknown Club';
-                const clubNameDisplay = truncateText(clubName, 25);
-                const clubId = sticker.clubs?.id || null;
-
-                let entry = '<a href="/stickers/' + sticker.id + '.html" class="sticker-link">' + sticker.id + '</a>, ';
-
-                if (clubId) {
-                    entry += '<a href="/clubs/' + clubId + '.html" class="club-link" title="' + clubName + '">' + clubNameDisplay + '</a>';
-                } else {
-                    entry += '<span title="' + clubName + '">' + clubNameDisplay + '</span>';
-                }
-
-                entry += '.';
-
-                html += '<li>' + entry + '</li>';
-            });
-
-            html += '</ul>';
+            html += '<tr>';
+            html += `<td class="rank-cell">${index + 1}.</td>`;
+            html += `<td class="sticker-cell"><a href="/stickers/${sticker.id}.html">${sticker.id}</a></td>`;
+            html += '<td class="club-cell">';
+            if (clubId) {
+                html += `<a href="/clubs/${clubId}.html" title="${clubName}">${clubNameDisplay}</a>`;
+            } else {
+                html += `<span title="${clubName}">${clubNameDisplay}</span>`;
+            }
+            html += '</td>';
+            html += `<td class="date-cell">${dateDisplay}</td>`;
+            html += '</tr>';
         });
 
+        html += '</tbody>';
+        html += '</table>';
         html += '<a href="/stickerlog.html" class="view-full-log-link">View full stickerLog</a>';
         html += '</div>';
 

--- a/style.css
+++ b/style.css
@@ -1729,38 +1729,80 @@ body.home-page #home-title #total-stickers {
     border-bottom: 1px dashed var(--color-border);
 }
 
-.last-stickers-date-header {
-    margin-top: calc(var(--spacing-unit) * 2);
-    margin-bottom: calc(var(--spacing-unit) * 1);
-    color: var(--color-text);
+/* Last stickers table */
+.last-stickers-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    text-align: left;
     font-size: 1em;
+}
+
+.last-stickers-table tbody tr {
+    border-bottom: 1px solid var(--color-border);
+    transition: background-color 0.2s ease;
+}
+
+.last-stickers-table tbody tr:last-child {
+    border-bottom: none;
+}
+
+.last-stickers-table td {
+    padding: calc(var(--spacing-unit) * 1) calc(var(--spacing-unit) * 0.75);
+    vertical-align: middle;
+}
+
+.last-stickers-table .rank-cell {
+    color: var(--color-rank);
     font-weight: 600;
+    text-align: right;
+    min-width: 2.5em;
+    white-space: nowrap;
 }
 
-.last-stickers-date-header:first-of-type {
-    margin-top: 0;
+.last-stickers-table .sticker-cell {
+    text-align: left;
+    min-width: 4em;
+    white-space: nowrap;
 }
 
-.last-stickers-list {
-    list-style: none;
-    padding-left: 0;
-}
-
-.last-stickers-list li {
-    margin-bottom: var(--spacing-unit);
-    font-size: 1.1em;
-}
-
-.last-stickers-list .sticker-link,
-.last-stickers-list .club-link {
+.last-stickers-table .sticker-cell a {
     color: var(--color-info-text);
     text-decoration: none;
     font-weight: 500;
 }
 
+.last-stickers-table .club-cell {
+    text-align: left;
+    width: 100%;
+    padding-right: calc(var(--spacing-unit) * 1);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.last-stickers-table .club-cell a {
+    color: var(--color-info-text);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.last-stickers-table .date-cell {
+    text-align: right;
+    font-weight: 500;
+    color: var(--color-info-text);
+    min-width: 4em;
+    white-space: nowrap;
+    font-size: 0.9em;
+}
+
 @media (hover: hover) {
-    .last-stickers-list .sticker-link:hover,
-    .last-stickers-list .club-link:hover {
+    .last-stickers-table tbody tr:hover {
+        background-color: var(--color-secondary-bg-hover);
+    }
+
+    .last-stickers-table .sticker-cell a:hover,
+    .last-stickers-table .club-cell a:hover {
         color: var(--color-link);
         text-decoration: underline;
     }
@@ -1844,6 +1886,9 @@ body.home-page #home-title #total-stickers {
     text-align: left;
     width: 100%;
     padding-right: calc(var(--spacing-unit) * 1);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .most-rated-table .club-cell a {
@@ -3327,6 +3372,9 @@ body.daily-mode .game-info #timer {
     text-align: left;
     width: 100%;
     padding-right: calc(var(--spacing-unit) * 1);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .club-cell a {


### PR DESCRIPTION
- Convert Last stickers section to table format matching Most rated section
- Table shows: rank, sticker number, club name, date (instead of grouped by date list)
- Add white-space: nowrap, overflow: hidden, text-overflow: ellipsis to all .club-cell elements
- Prevents club names from wrapping to multiple lines in all tables (rating page, catalogue sections)
- Both catalogue sections now have identical table structure for visual consistency

https://claude.ai/code/session_gcKmp