### PR TITLE
Self-healing image optimization: safety-net + cron reconciler

### DIFF
--- a/.github/workflows/generate-sticker-pages.yml
+++ b/.github/workflows/generate-sticker-pages.yml
@@ -150,6 +150,18 @@ jobs:
 
           echo "image_optimization=success" >> $GITHUB_OUTPUT
 
+      - name: Safety-net — optimize any missing recent images
+        if: always()
+        working-directory: ./scripts
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        continue-on-error: true
+        run: |
+          # Picks up stickers whose workflow run was cancelled by concurrency group
+          # (last 2 days, HEAD-checks _web.webp existence, optimizes only what's missing)
+          node optimize-images.js --missing-only --days=2
+
       - name: Regenerate city pages
         if: steps.get-ids.outputs.sticker_ids != ''
         working-directory: ./scripts

--- a/.github/workflows/reconcile-images.yml
+++ b/.github/workflows/reconcile-images.yml
@@ -1,0 +1,49 @@
+name: Reconcile Missing Optimized Images
+
+on:
+  schedule:
+    # Every 15 minutes — catches any stickers whose generate-sticker-pages
+    # run was cancelled by the concurrency group and whose safety-net step
+    # also didn't run.
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Check stickers from last N days (default 7)'
+        required: false
+        default: '7'
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reconcile-images
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        working-directory: ./scripts
+        run: npm install
+
+      - name: Optimize missing images
+        working-directory: ./scripts
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          DAYS="${{ github.event.inputs.days || '7' }}"
+          node optimize-images.js --missing-only --days=$DAYS

--- a/scripts/optimize-images.js
+++ b/scripts/optimize-images.js
@@ -27,8 +27,10 @@ dotenv.config();
 function parseArgs() {
     const args = {
         dryRun: process.argv.includes('--dry-run'),
+        missingOnly: process.argv.includes('--missing-only'),
         fromId: null,
-        onlyIds: null
+        onlyIds: null,
+        days: null
     };
 
     for (const arg of process.argv) {
@@ -37,6 +39,9 @@ function parseArgs() {
         }
         if (arg.startsWith('--only=')) {
             args.onlyIds = arg.split('=')[1].split(',').map(id => parseInt(id.trim(), 10));
+        }
+        if (arg.startsWith('--days=')) {
+            args.days = parseInt(arg.split('=')[1], 10);
         }
     }
 
@@ -79,7 +84,9 @@ const CONFIG = {
     // Command line options
     DRY_RUN: ARGS.dryRun,
     FROM_ID: ARGS.fromId,
-    ONLY_IDS: ARGS.onlyIds
+    ONLY_IDS: ARGS.onlyIds,
+    MISSING_ONLY: ARGS.missingOnly,
+    DAYS: ARGS.days
 };
 
 // Validate configuration
@@ -117,10 +124,16 @@ async function getAllStickers() {
         return data || [];
     }
 
-    // Otherwise fetch all (with optional --from filter)
+    // Otherwise fetch all (with optional --from and --days filter)
     const allStickers = [];
     let offset = 0;
     const limit = 1000;
+
+    let sinceIso = null;
+    if (CONFIG.DAYS) {
+        sinceIso = new Date(Date.now() - CONFIG.DAYS * 86400_000).toISOString();
+        console.log(`(limiting to stickers created since ${sinceIso})`);
+    }
 
     while (true) {
         let query = supabase
@@ -131,6 +144,10 @@ async function getAllStickers() {
         // Apply --from filter
         if (CONFIG.FROM_ID) {
             query = query.gte('id', CONFIG.FROM_ID);
+        }
+
+        if (sinceIso) {
+            query = query.gte('created_at', sinceIso);
         }
 
         query = query.range(offset, offset + limit - 1);
@@ -423,11 +440,33 @@ async function main() {
 
     try {
         // Get all stickers
-        const stickers = await getAllStickers();
+        let stickers = await getAllStickers();
 
         if (stickers.length === 0) {
             console.log('No stickers found in database.');
             return;
+        }
+
+        // --missing-only: pre-filter to stickers without _web.webp in Storage
+        if (CONFIG.MISSING_ONLY) {
+            console.log(`\nChecking _web.webp existence for ${stickers.length} stickers...`);
+            const CHECK_CONCURRENCY = 20;
+            const missing = [];
+            for (let i = 0; i < stickers.length; i += CHECK_CONCURRENCY) {
+                const batch = stickers.slice(i, i + CHECK_CONCURRENCY);
+                const flags = await Promise.all(batch.map(async (s) => {
+                    const p = extractStoragePath(s.image_url);
+                    if (!p) return false;
+                    return !(await optimizedVersionExists(p, CONFIG.WEB_SUFFIX));
+                }));
+                batch.forEach((s, idx) => { if (flags[idx]) missing.push(s); });
+            }
+            console.log(`Missing optimized versions: ${missing.length} of ${stickers.length}`);
+            stickers = missing;
+            if (stickers.length === 0) {
+                console.log('Nothing to do.');
+                return;
+            }
         }
 
         // Process


### PR DESCRIPTION
## Problem
Rapid sticker uploads (e.g. 18.04: 31 стікерів за 10 хв, по одному кожні ~20с) тригерять `generate-sticker-pages` на кожен. Concurrency group дозволяє 1 running + 1 queued — решта отримують `cancelled`. Скасовані рани не запускають крок `Optimize images`, і `_web.webp` / `_thumb.webp` не створюються в Supabase Storage. HTML-сторінка посилається на webp → 404 → зламана картинка.

Приклад: 13 із 31 стікерів 18.04 постраждали (вже пофікшено вручну).

## Summary
- `optimize-images.js`: нові прапорці `--missing-only` і `--days=N`. Попередньо фільтрує список стікерів, роблячи HEAD на `_web.webp` у Storage; оптимізує тільки відсутні.
- `generate-sticker-pages.yml`: додано `if: always()` safety-net крок у кінці воркфлоу — викликає `--missing-only --days=2`. Самолікується всередині тієї ж пачки ранів.
- `reconcile-images.yml` (новий): cron кожні 15 хв + manual dispatch, `--missing-only --days=7`. Ловить крайні випадки, коли safety-net теж не відпрацював.

## Test plan
- [x] Запущено локально `node optimize-images.js --missing-only --days=2` → "Missing: 0 of 31" (після ручного фіксу).
- [ ] Після merge переконатися що cron `reconcile-images.yml` стартував (Actions tab).
- [ ] Наступний mass-upload має автоматично завершитись без пропущених картинок.