### PR TITLE
fix: badge only on single sticker page

### DIFF
--- a/clubs/617.html
+++ b/clubs/617.html
@@ -210,16 +210,18 @@
                 <a href="/stickers/311.html" class="sticker-preview-link">
                     <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Bodo_glimt/IMG_5675_thumb.webp?"
                          alt="Bodo glimt street sticker #311 -- Norway football"
+                         data-sticker-id="311"
                          class="sticker-preview-image"
                          loading="lazy"
-                         decoding="async" data-sticker-id="311">
+                         decoding="async">
                 </a>
                 <a href="/stickers/2333.html" class="sticker-preview-link">
                     <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_617%2F1749912267389_IMG_5996_thumb.webp"
                          alt="Bodo glimt street sticker #2333 -- Norway football"
+                         data-sticker-id="2333"
                          class="sticker-preview-image"
                          loading="lazy"
-                         decoding="async" data-sticker-id="2333">
+                         decoding="async">
                 </a>
             </div>
             
@@ -249,7 +251,7 @@
 <li><a href="/clubs/1116.html">IK Start</a> (1)</li>
 <li><a href="/clubs/105.html">Lyn 1896 FK</a> (1)</li>
 <li><a href="/clubs/1115.html">Moss FK</a> (1)</li>
-<li><a href="/countries/NOR.html">View all 16 clubs →</a></li>
+<li><a href="/countries/NOR.html">View all 17 clubs →</a></li>
 </ul>
 </div>
 
@@ -291,6 +293,7 @@
                     marker.on('mouseover', function() { this.openPopup(); });
                     marker.on('click', function() { this.openPopup(); });
                 })();
+
                 
             }
         });

--- a/clubs/618.html
+++ b/clubs/618.html
@@ -211,16 +211,18 @@ Founded in 1948 as the team of the Ministry of Internal Affairs, following the m
                 <a href="/stickers/312.html" class="sticker-preview-link">
                     <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Dinamo_Bucuresti/IMG_4155_(2)_thumb.webp?"
                          alt="FC Dinamo București street sticker #312 -- Romania football"
+                         data-sticker-id="312"
                          class="sticker-preview-image"
                          loading="lazy"
-                         decoding="async" data-sticker-id="312">
+                         decoding="async">
                 </a>
                 <a href="/stickers/313.html" class="sticker-preview-link">
                     <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Dinamo_Bucuresti/IMG_8397_(1)_thumb.webp?"
                          alt="FC Dinamo București street sticker #313 -- Romania football"
+                         data-sticker-id="313"
                          class="sticker-preview-image"
                          loading="lazy"
-                         decoding="async" data-sticker-id="313">
+                         decoding="async">
                 </a>
             </div>
             
@@ -232,12 +234,12 @@ Founded in 1948 as the team of the Ministry of Internal Affairs, following the m
         <div class="other-clubs-section">
 <h3>Other clubs from Romania</h3>
 <ul class="other-clubs-list">
-<li><a href="/clubs/614.html">FCSB</a> (7)</li>
-<li><a href="/clubs/633.html">CS Universitatea Craiova</a> (3)</li>
+<li><a href="/clubs/614.html">FCSB</a> (8)</li>
+<li><a href="/clubs/633.html">CS Universitatea Craiova</a> (5)</li>
 <li><a href="/clubs/637.html">Rapid Bucuresti</a> (3)</li>
+<li><a href="/clubs/22.html">FC Corvinul Hunedoara</a> (2)</li>
 <li><a href="/clubs/646.html">FC Politehnica Iași</a> (2)</li>
 <li><a href="/clubs/628.html">CSM Reșița</a> (1)</li>
-<li><a href="/clubs/22.html">FC Corvinul Hunedoara</a> (1)</li>
 <li><a href="/clubs/643.html">FC Politehnica Timișoara</a> (1)</li>
 <li><a href="/clubs/642.html">FC UTA Arad</a> (1)</li>
 </ul>

--- a/clubs/855.html
+++ b/clubs/855.html
@@ -190,9 +190,10 @@
                 <a href="/stickers/1204.html" class="sticker-preview-link">
                     <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TUS_Hiltrup/IMG_7718_thumb.webp?"
                          alt="TUS Hiltrup street sticker #1204 -- Germany football"
+                         data-sticker-id="1204"
                          class="sticker-preview-image"
                          loading="lazy"
-                         decoding="async" data-sticker-id="1204">
+                         decoding="async">
                 </a>
             </div>
             
@@ -204,17 +205,17 @@
         <div class="other-clubs-section">
 <h3>Other clubs from Germany</h3>
 <ul class="other-clubs-list">
-<li><a href="/clubs/896.html">TSV 1860 München</a> (60)</li>
-<li><a href="/clubs/947.html">VfB Stuttgart</a> (59)</li>
-<li><a href="/clubs/879.html">Dynamo Dresden</a> (58)</li>
-<li><a href="/clubs/922.html">1 FC Nürnberg</a> (54)</li>
+<li><a href="/clubs/947.html">VfB Stuttgart</a> (64)</li>
+<li><a href="/clubs/896.html">TSV 1860 München</a> (61)</li>
+<li><a href="/clubs/879.html">Dynamo Dresden</a> (59)</li>
+<li><a href="/clubs/922.html">1 FC Nürnberg</a> (56)</li>
 <li><a href="/clubs/856.html">FC Bayern Munich</a> (52)</li>
-<li><a href="/clubs/945.html">1 FC Union Berlin</a> (38)</li>
-<li><a href="/clubs/881.html">FC St Pauli</a> (35)</li>
-<li><a href="/clubs/880.html">Hertha BSC</a> (35)</li>
+<li><a href="/clubs/945.html">1 FC Union Berlin</a> (40)</li>
+<li><a href="/clubs/880.html">Hertha BSC</a> (40)</li>
+<li><a href="/clubs/925.html">Eintracht Frankfurt</a> (36)</li>
+<li><a href="/clubs/881.html">FC St Pauli</a> (36)</li>
 <li><a href="/clubs/949.html">FC Schalke 04</a> (34)</li>
-<li><a href="/clubs/928.html">FC Augsburg</a> (32)</li>
-<li><a href="/countries/DEU.html">View all 147 clubs →</a></li>
+<li><a href="/countries/DEU.html">View all 151 clubs →</a></li>
 </ul>
 </div>
 

--- a/countries/DEU.html
+++ b/countries/DEU.html
@@ -1050,42 +1050,42 @@
             </div>
             <div class="cat-clubs-strip">
                 <a href="/clubs/947.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_947%2F1751114262225_IMG_6075_thumb.webp" alt="VfB Stuttgart sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_947%2F1751114262225_IMG_6075_thumb.webp" alt="VfB Stuttgart sticker" data-sticker-id="2362" loading="lazy" decoding="async">
                     <span class="cat-club-label">VfB Stuttgart</span>
                     <span class="cat-club-count">64 stickers</span>
                 </a>
                 <a href="/clubs/896.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TSV_1860_Munchen/IMG_1173_thumb.webp" alt="TSV 1860 München sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TSV_1860_Munchen/IMG_1173_thumb.webp" alt="TSV 1860 München sticker" data-sticker-id="1489" loading="lazy" decoding="async">
                     <span class="cat-club-label">TSV 1860 München</span>
                     <span class="cat-club-count">61 stickers</span>
                 </a>
                 <a href="/clubs/879.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Dynamo_Dresden/IMG_1917_thumb.webp" alt="Dynamo Dresden sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Dynamo_Dresden/IMG_1917_thumb.webp" alt="Dynamo Dresden sticker" data-sticker-id="1323" loading="lazy" decoding="async">
                     <span class="cat-club-label">Dynamo Dresden</span>
                     <span class="cat-club-count">59 stickers</span>
                 </a>
                 <a href="/clubs/922.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_FC_Nurnberg/IMG_1582_thumb.webp" alt="1 FC Nürnberg sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_FC_Nurnberg/IMG_1582_thumb.webp" alt="1 FC Nürnberg sticker" data-sticker-id="1594" loading="lazy" decoding="async">
                     <span class="cat-club-label">1 FC Nürnberg</span>
                     <span class="cat-club-count">56 stickers</span>
                 </a>
                 <a href="/clubs/856.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Bayern_Munich/IMG_1180_thumb.webp" alt="FC Bayern Munich sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Bayern_Munich/IMG_1180_thumb.webp" alt="FC Bayern Munich sticker" data-sticker-id="1229" loading="lazy" decoding="async">
                     <span class="cat-club-label">FC Bayern Munich</span>
                     <span class="cat-club-count">52 stickers</span>
                 </a>
                 <a href="/clubs/945.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_FC_Union_Berlin/IMG_3486_thumb.webp" alt="1 FC Union Berlin sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_FC_Union_Berlin/IMG_3486_thumb.webp" alt="1 FC Union Berlin sticker" data-sticker-id="1788" loading="lazy" decoding="async">
                     <span class="cat-club-label">1 FC Union Berlin</span>
                     <span class="cat-club-count">40 stickers</span>
                 </a>
                 <a href="/clubs/880.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Hertha_BSC/IMG_0995_thumb.webp" alt="Hertha BSC sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Hertha_BSC/IMG_0995_thumb.webp" alt="Hertha BSC sticker" data-sticker-id="1374" loading="lazy" decoding="async">
                     <span class="cat-club-label">Hertha BSC</span>
                     <span class="cat-club-count">40 stickers</span>
                 </a>
                 <a href="/clubs/925.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Eintracht_Frankfurt/IMG_8862_thumb.webp" alt="Eintracht Frankfurt sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Eintracht_Frankfurt/IMG_8862_thumb.webp" alt="Eintracht Frankfurt sticker" data-sticker-id="1658" loading="lazy" decoding="async">
                     <span class="cat-club-label">Eintracht Frankfurt</span>
                     <span class="cat-club-count">36 stickers</span>
                 </a></div>
@@ -1101,1057 +1101,1057 @@
             <div class="cat-country-grid">
                 
                 <a href="/clubs/852.html" class="cat-country-card" title="1 FC Heidenheim">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_852%2F1755812675293_IMG_6169_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_852%2F1755812675293_IMG_6169_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2445" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 1 FC Heidenheim</span>
                         <span class="cat-country-meta">3 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/972.html" class="cat-country-card" title="1 FC Kaiserslautern">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_FC_Kaiserslautern/IMG_9462_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_FC_Kaiserslautern/IMG_9462_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1955" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 1 FC Kaiserslautern</span>
                         <span class="cat-country-meta">17 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/937.html" class="cat-country-card" title="1 FC Köln">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_937%2F1749912217937_IMG_5999_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_937%2F1749912217937_IMG_5999_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2331" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 1 FC Köln</span>
                         <span class="cat-country-meta">22 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/891.html" class="cat-country-card" title="1 fc Lauchhau-lauchäcker 04">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_fc_Lauchhau-lauchacker_04/IMG_1118_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_fc_Lauchhau-lauchacker_04/IMG_1118_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1432" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 1 fc Lauchhau-lauchäcker 04</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/893.html" class="cat-country-card" title="1 FC Lokomotive Leipzig">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_FC_Lokomotive_Leipzig/IMG_0561_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_FC_Lokomotive_Leipzig/IMG_0561_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1434" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 1 FC Lokomotive Leipzig</span>
                         <span class="cat-country-meta">5 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/957.html" class="cat-country-card" title="1 FC Magdeburg">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_FC_Magdeburg/IMG_8614_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_FC_Magdeburg/IMG_8614_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1893" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 1 FC Magdeburg</span>
                         <span class="cat-country-meta">13 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/922.html" class="cat-country-card" title="1 FC Nürnberg">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_FC_Nurnberg/IMG_1582_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_FC_Nurnberg/IMG_1582_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1594" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 1 FC Nürnberg</span>
                         <span class="cat-country-meta">56 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/908.html" class="cat-country-card" title="1 FC Rodewisch eV">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_FC_Rodewisch_eV/IMG_3481_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_FC_Rodewisch_eV/IMG_3481_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1544" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 1 FC Rodewisch eV</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/864.html" class="cat-country-card" title="1 FC Saarbrücken">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_864/1766230107334_IMG_76391_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_864/1766230107334_IMG_76391_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2846" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 1 FC Saarbrücken</span>
                         <span class="cat-country-meta">13 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/884.html" class="cat-country-card" title="1 FC Stern Mögglingen">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_FC_Stern_Mogglingen/IMG_8122_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_FC_Stern_Mogglingen/IMG_8122_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1418" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 1 FC Stern Mögglingen</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/945.html" class="cat-country-card" title="1 FC Union Berlin">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_FC_Union_Berlin/IMG_3486_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_FC_Union_Berlin/IMG_3486_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1788" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 1 FC Union Berlin</span>
                         <span class="cat-country-meta">40 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/866.html" class="cat-country-card" title="1 FCA Darmstadt">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_FCA_Darmstadt/IMG_8641_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/1_FCA_Darmstadt/IMG_8641_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1285" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 1 FCA Darmstadt</span>
                         <span class="cat-country-meta">6 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/953.html" class="cat-country-card" title="1 FSV Mainz 05">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_953/1760189326921_IMG_73121_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_953/1760189326921_IMG_73121_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2674" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 1 FSV Mainz 05</span>
                         <span class="cat-country-meta">9 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/919.html" class="cat-country-card" title="Alemannia Aachen">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Alemannia_Aachen/IMG_8652_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Alemannia_Aachen/IMG_8652_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1570" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Alemannia Aachen</span>
                         <span class="cat-country-meta">7 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/1159.html" class="cat-country-card" title="Altonaer FC von 1893">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1159/1772971077138_IMG_7991_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1159/1772971077138_IMG_7991_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="3009" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Altonaer FC von 1893</span>
                         <span class="cat-country-meta">2 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/1102.html" class="cat-country-card" title="Arminia Bielefeld">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1102/1759592495349_IMG_7228_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1102/1759592495349_IMG_7228_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2622" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Arminia Bielefeld</span>
                         <span class="cat-country-meta">9 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/943.html" class="cat-country-card" title="ASV Harthausen">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/ASV_Harthausen/IMG_4136_(1)_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/ASV_Harthausen/IMG_4136_(1)_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1777" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 ASV Harthausen</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/900.html" class="cat-country-card" title="Bayer 04 Leverkusen">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Bayer_04_Leverkusen/IMG_7912_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Bayer_04_Leverkusen/IMG_7912_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1518" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Bayer 04 Leverkusen</span>
                         <span class="cat-country-meta">13 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/887.html" class="cat-country-card" title="Berliner SC">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Berliner_SC/IMG_5878_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Berliner_SC/IMG_5878_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1426" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Berliner SC</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/1055.html" class="cat-country-card" title="BFC Dynamo Berlin">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1055%2F1749912393758_IMG_5988_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1055%2F1749912393758_IMG_5988_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2334" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 BFC Dynamo Berlin</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/948.html" class="cat-country-card" title="Borussia Dortmund">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_948/1767036555136_IMG_7767_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_948/1767036555136_IMG_7767_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2871" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Borussia Dortmund</span>
                         <span class="cat-country-meta">23 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/961.html" class="cat-country-card" title="Borussia Mönchengladbach">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Borussia_Monchengladbach/IMG_0867_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Borussia_Monchengladbach/IMG_0867_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1917" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Borussia Mönchengladbach</span>
                         <span class="cat-country-meta">24 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/1132.html" class="cat-country-card" title="BSC Schevenhütte e.V.">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1132/1763675116492_IMG_7429_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1132/1763675116492_IMG_7429_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2745" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 BSC Schevenhütte e.V.</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/934.html" class="cat-country-card" title="BSC Süd 05">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/BSC_Sud_05/IMG_1908_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/BSC_Sud_05/IMG_1908_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1750" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 BSC Süd 05</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/870.html" class="cat-country-card" title="BV Segendorf">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/BV_Segendorf/IMG_1048_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/BV_Segendorf/IMG_1048_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1294" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 BV Segendorf</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/915.html" class="cat-country-card" title="Chemie Leipzig">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Chemie_Leipzig/IMG_0042_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Chemie_Leipzig/IMG_0042_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1559" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Chemie Leipzig</span>
                         <span class="cat-country-meta">10 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/892.html" class="cat-country-card" title="DJK Ottenhofen">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/DJK_Ottenhofen/IMG_1479_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/DJK_Ottenhofen/IMG_1479_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1433" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 DJK Ottenhofen</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/879.html" class="cat-country-card" title="Dynamo Dresden">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Dynamo_Dresden/IMG_1917_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Dynamo_Dresden/IMG_1917_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1323" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Dynamo Dresden</span>
                         <span class="cat-country-meta">59 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/1058.html" class="cat-country-card" title="Eibenstocker BC 1911 e.V.">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1058%2F1750597827404_IMG_6022_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1058%2F1750597827404_IMG_6022_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2351" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Eibenstocker BC 1911 e.V.</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/912.html" class="cat-country-card" title="Eintracht Braunschweig">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Eintracht_Braunschweig/IMG_0278_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Eintracht_Braunschweig/IMG_0278_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1552" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Eintracht Braunschweig</span>
                         <span class="cat-country-meta">13 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/925.html" class="cat-country-card" title="Eintracht Frankfurt">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Eintracht_Frankfurt/IMG_8862_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Eintracht_Frankfurt/IMG_8862_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1658" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Eintracht Frankfurt</span>
                         <span class="cat-country-meta">36 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/885.html" class="cat-country-card" title="ESV 1927 Regensburg">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/ESV_1927_Regensburg/IMG_9735_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/ESV_1927_Regensburg/IMG_9735_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1419" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 ESV 1927 Regensburg</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/1151.html" class="cat-country-card" title="FC 08 Homburg">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1151/1769892953377_IMG_7867_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1151/1769892953377_IMG_7867_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2961" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FC 08 Homburg</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/920.html" class="cat-country-card" title="FC 1911 Horchheim">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_1911_Horchheim/IMG_9551_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_1911_Horchheim/IMG_9551_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1574" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FC 1911 Horchheim</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/928.html" class="cat-country-card" title="FC Augsburg">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Augsburg/IMG_0914_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Augsburg/IMG_0914_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1717" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FC Augsburg</span>
                         <span class="cat-country-meta">32 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/856.html" class="cat-country-card" title="FC Bayern Munich">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Bayern_Munich/IMG_1180_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Bayern_Munich/IMG_1180_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1229" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FC Bayern Munich</span>
                         <span class="cat-country-meta">52 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/897.html" class="cat-country-card" title="FC Carl Zeiss Jena">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Carl_Zeiss_Jena/IMG_9679_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Carl_Zeiss_Jena/IMG_9679_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1506" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FC Carl Zeiss Jena</span>
                         <span class="cat-country-meta">9 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/969.html" class="cat-country-card" title="FC Dombühl eV">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Dombuhl_eV/IMG_1148_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Dombuhl_eV/IMG_1148_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1947" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FC Dombühl eV</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/924.html" class="cat-country-card" title="FC Empor Weimar">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Empor_Weimar/IMG_3433_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Empor_Weimar/IMG_3433_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1649" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FC Empor Weimar</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/869.html" class="cat-country-card" title="FC Energie Cottbus">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Energie_Cottbus/IMG_1127_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Energie_Cottbus/IMG_1127_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1289" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FC Energie Cottbus</span>
                         <span class="cat-country-meta">10 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/910.html" class="cat-country-card" title="FC Erzgebirge Aue">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_910%2F1749910896499_IMG_5944_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_910%2F1749910896499_IMG_5944_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2317" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FC Erzgebirge Aue</span>
                         <span class="cat-country-meta">4 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/1182.html" class="cat-country-card" title="FC Hengst Macke e.V.">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1182/1776079420498_IMG_9440_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1182/1776079420498_IMG_9440_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="3313" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FC Hengst Macke e.V.</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/954.html" class="cat-country-card" title="FC Ingolstadt 04">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Ingolstadt_04/IMG_0712_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Ingolstadt_04/IMG_0712_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1888" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FC Ingolstadt 04</span>
                         <span class="cat-country-meta">2 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/926.html" class="cat-country-card" title="FC Internationale Memmingen">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Internationale_Memmingen/IMG_0994_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Internationale_Memmingen/IMG_0994_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1668" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FC Internationale Memmingen</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/895.html" class="cat-country-card" title="FC Land Wursten">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Land_Wursten/IMG_1814_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Land_Wursten/IMG_1814_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1448" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FC Land Wursten</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/956.html" class="cat-country-card" title="FC Rot-Weiß Erfurt">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_956%2F1746544794150_IMG_3587_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_956%2F1746544794150_IMG_3587_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1965" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FC Rot-Weiß Erfurt</span>
                         <span class="cat-country-meta">3 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/949.html" class="cat-country-card" title="FC Schalke 04">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_949/1760043677305_IMG_7269_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_949/1760043677305_IMG_7269_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2641" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FC Schalke 04</span>
                         <span class="cat-country-meta">34 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/876.html" class="cat-country-card" title="FC Schönheide">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Schonheide/IMG_3862_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Schonheide/IMG_3862_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1302" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FC Schönheide</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/881.html" class="cat-country-card" title="FC St Pauli">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_St_Pauli/IMG_8362_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_St_Pauli/IMG_8362_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1403" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FC St Pauli</span>
                         <span class="cat-country-meta">36 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/888.html" class="cat-country-card" title="FC Stella 1911 e V Bevergern">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Stella_1911_e_V_Bevergern/IMG_9027_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Stella_1911_e_V_Bevergern/IMG_9027_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1427" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FC Stella 1911 e V Bevergern</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/936.html" class="cat-country-card" title="FC Union Tornesch">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Union_Tornesch/IMG_9599_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Union_Tornesch/IMG_9599_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1752" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FC Union Tornesch</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/959.html" class="cat-country-card" title="FC Westharz">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Westharz/IMG_1092_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Westharz/IMG_1092_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1899" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FC Westharz</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/851.html" class="cat-country-card" title="Fortuna Düsseldorf">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Fortuna_Dusseldorf/IMG_8508_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Fortuna_Dusseldorf/IMG_8508_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1198" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Fortuna Düsseldorf</span>
                         <span class="cat-country-meta">9 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/1174.html" class="cat-country-card" title="Friedrichshagener SV 1912">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1174/1775994389077_IMG_9181_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1174/1775994389077_IMG_9181_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="3244" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Friedrichshagener SV 1912</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/935.html" class="cat-country-card" title="FSV Alemannia 1911 e V Mainz-Laubenheim">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FSV_Alemannia_1911_e_V_Mainz-Laubenheim/IMG_1435_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FSV_Alemannia_1911_e_V_Mainz-Laubenheim/IMG_1435_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1751" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FSV Alemannia 1911 e V Mainz-Laubenheim</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/1180.html" class="cat-country-card" title="FSV Blau Weiß Schwarzenberg">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1180/1776001371428_IMG_5754_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1180/1776001371428_IMG_5754_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="3290" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FSV Blau Weiß Schwarzenberg</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/1136.html" class="cat-country-card" title="FSV Löberitz">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1136/1763895798677_IMG_7465_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1136/1763895798677_IMG_7465_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2764" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FSV Löberitz</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/942.html" class="cat-country-card" title="FV Eintracht Niesky">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FV_Eintracht_Niesky/IMG_9566_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FV_Eintracht_Niesky/IMG_9566_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1776" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FV Eintracht Niesky</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/868.html" class="cat-country-card" title="FV Kusel 1919">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FV_Kusel_1919/IMG_0705_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FV_Kusel_1919/IMG_0705_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1287" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 FV Kusel 1919</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/940.html" class="cat-country-card" title="Germania Wernigerode">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Germania_Wernigerode/IMG_0842_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Germania_Wernigerode/IMG_0842_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1774" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Germania Wernigerode</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/965.html" class="cat-country-card" title="Hallescher FC">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Hallescher_FC/IMG_9620_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Hallescher_FC/IMG_9620_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1934" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Hallescher FC</span>
                         <span class="cat-country-meta">7 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/930.html" class="cat-country-card" title="Hamburger SV">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Hamburger_SV/IMG_5434_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Hamburger_SV/IMG_5434_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1736" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Hamburger SV</span>
                         <span class="cat-country-meta">33 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/877.html" class="cat-country-card" title="Hannover 96">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Hannover_96/IMG_9681_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Hannover_96/IMG_9681_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1306" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Hannover 96</span>
                         <span class="cat-country-meta">21 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/927.html" class="cat-country-card" title="Hansa Rostock">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Hansa_Rostock/IMG_4410_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Hansa_Rostock/IMG_4410_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1671" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Hansa Rostock</span>
                         <span class="cat-country-meta">30 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/880.html" class="cat-country-card" title="Hertha BSC">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Hertha_BSC/IMG_0995_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Hertha_BSC/IMG_0995_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1374" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Hertha BSC</span>
                         <span class="cat-country-meta">40 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/960.html" class="cat-country-card" title="HFC Falke">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/HFC_Falke/IMG_0065_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/HFC_Falke/IMG_0065_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1900" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 HFC Falke</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/921.html" class="cat-country-card" title="Holstein Kiel">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Holstein_Kiel/IMG_0295_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Holstein_Kiel/IMG_0295_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1580" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Holstein Kiel</span>
                         <span class="cat-country-meta">6 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/914.html" class="cat-country-card" title="JFG Leitenbachtal">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/JFG_Leitenbachtal/IMG_1377_(1)_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/JFG_Leitenbachtal/IMG_1377_(1)_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1558" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 JFG Leitenbachtal</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/923.html" class="cat-country-card" title="JFV2016 Grob-umstadt">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/JFV2016_Grob-umstadt/IMG_0800_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/JFV2016_Grob-umstadt/IMG_0800_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1648" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 JFV2016 Grob-umstadt</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/874.html" class="cat-country-card" title="Joga Barnito">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Joga_Barnito/IMG_1961_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Joga_Barnito/IMG_1961_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1300" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Joga Barnito</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/906.html" class="cat-country-card" title="Karlsruher SC">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Karlsruher_SC/IMG_2749_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Karlsruher_SC/IMG_2749_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1540" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Karlsruher SC</span>
                         <span class="cat-country-meta">12 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/1121.html" class="cat-country-card" title="KFV Wittbrietzen">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1121/1760871919769_IMG_73663_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1121/1760871919769_IMG_73663_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2698" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 KFV Wittbrietzen</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/904.html" class="cat-country-card" title="Kickers Offenbach">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Kickers_Offenbach/IMG_0679_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Kickers_Offenbach/IMG_0679_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1531" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Kickers Offenbach</span>
                         <span class="cat-country-meta">6 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/1140.html" class="cat-country-card" title="KSV Hessen Kassel">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1140/1766182665106_IMG_7632_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1140/1766182665106_IMG_7632_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2802" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 KSV Hessen Kassel</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/952.html" class="cat-country-card" title="MSV Duisburg">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_952/1772970930685_IMG_7990_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_952/1772970930685_IMG_7990_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="3008" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 MSV Duisburg</span>
                         <span class="cat-country-meta">6 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/1077.html" class="cat-country-card" title="MTV Gamsen">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1077%2F1756040179640_IMG_6369_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1077%2F1756040179640_IMG_6369_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2459" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 MTV Gamsen</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/955.html" class="cat-country-card" title="Preusen Münster">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_955/1759591798209_IMG_7245_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_955/1759591798209_IMG_7245_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2619" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Preusen Münster</span>
                         <span class="cat-country-meta">4 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/850.html" class="cat-country-card" title="RB Leipzig">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_850/1766230693873_IMG_7740_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_850/1766230693873_IMG_7740_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2852" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 RB Leipzig</span>
                         <span class="cat-country-meta">5 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/1163.html" class="cat-country-card" title="Rendsburger Primaner Ruderclub">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1163/1773005677792_IMG_8216_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1163/1773005677792_IMG_8216_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="3054" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Rendsburger Primaner Ruderclub</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/1079.html" class="cat-country-card" title="RGU 1260 e. V.">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1079%2F1756041477665_IMG_6331_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1079%2F1756041477665_IMG_6331_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2471" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 RGU 1260 e. V.</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/1183.html" class="cat-country-card" title="Rot Weiss Ahlen e.V.">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1183/1776079603504_IMG_9443_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1183/1776079603504_IMG_9443_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="3314" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Rot Weiss Ahlen e.V.</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/903.html" class="cat-country-card" title="Rot-Weiss Essen">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Rot-Weiss_Essen/IMG_1416_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Rot-Weiss_Essen/IMG_1416_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1527" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Rot-Weiss Essen</span>
                         <span class="cat-country-meta">5 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/962.html" class="cat-country-card" title="Rot-Weiß Oberhausen">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_962/1769891115355_IMG_7913_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_962/1769891115355_IMG_7913_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2941" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Rot-Weiß Oberhausen</span>
                         <span class="cat-country-meta">4 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/871.html" class="cat-country-card" title="Roter stern Leipzig">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Roter_stern_Leipzig/IMG_9625_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Roter_stern_Leipzig/IMG_9625_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1295" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Roter stern Leipzig</span>
                         <span class="cat-country-meta">2 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/1059.html" class="cat-country-card" title="S.C. Hassbergen 1955">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1059%2F1750598540167_IMG_6045_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1059%2F1750598540167_IMG_6045_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2357" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 S.C. Hassbergen 1955</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/1057.html" class="cat-country-card" title="SC Berliner Amateure">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1057%2F1750597531967_IMG_6035_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1057%2F1750597531967_IMG_6035_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2347" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SC Berliner Amateure</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/1100.html" class="cat-country-card" title="SC Brühl">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1100/1759591765810_IMG_7246_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1100/1759591765810_IMG_7246_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2618" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SC Brühl</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/861.html" class="cat-country-card" title="SC Freiburg">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_861/1768765632695_IMG_7834_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_861/1768765632695_IMG_7834_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2908" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SC Freiburg</span>
                         <span class="cat-country-meta">13 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/865.html" class="cat-country-card" title="SC Harten">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SC_Harten/IMG_0799_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SC_Harten/IMG_0799_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1282" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SC Harten</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/890.html" class="cat-country-card" title="SC Paderborn 07">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SC_Paderborn_07/IMG_9749_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SC_Paderborn_07/IMG_9749_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1429" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SC Paderborn 07</span>
                         <span class="cat-country-meta">3 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/857.html" class="cat-country-card" title="SG Hettenhausen">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SG_Hettenhausen/IMG_9710_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SG_Hettenhausen/IMG_9710_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1251" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SG Hettenhausen</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/863.html" class="cat-country-card" title="SG Kirchen-Hausen">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SG_Kirchen-Hausen/IMG_1164_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SG_Kirchen-Hausen/IMG_1164_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1272" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SG Kirchen-Hausen</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/889.html" class="cat-country-card" title="SG Peterberg">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SG_Peterberg/IMG_9717_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SG_Peterberg/IMG_9717_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1428" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SG Peterberg</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/901.html" class="cat-country-card" title="SG Renchtal">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SG_Renchtal/IMG_1117_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SG_Renchtal/IMG_1117_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1521" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SG Renchtal</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/913.html" class="cat-country-card" title="Sommerda">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Sommerda/IMG_5865_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Sommerda/IMG_5865_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1557" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Sommerda</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/946.html" class="cat-country-card" title="Spvg 07 Hochheim">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Spvg_07_Hochheim/IMG_0721_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Spvg_07_Hochheim/IMG_0721_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1812" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Spvg 07 Hochheim</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/883.html" class="cat-country-card" title="SpVgg BISON">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SpVgg_BISON/IMG_0866_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SpVgg_BISON/IMG_0866_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1417" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SpVgg BISON</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/967.html" class="cat-country-card" title="SpVgg Greuther Fürth">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_967/1766229308122_IMG_7734_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_967/1766229308122_IMG_7734_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2829" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SpVgg Greuther Fürth</span>
                         <span class="cat-country-meta">4 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/971.html" class="cat-country-card" title="Spvgg Haiderbach">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Spvgg_Haiderbach/IMG_1126_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Spvgg_Haiderbach/IMG_1126_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1949" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Spvgg Haiderbach</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/963.html" class="cat-country-card" title="SSV Jahn Regensburg">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SSV_Jahn_Regensburg/IMG_8352_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SSV_Jahn_Regensburg/IMG_8352_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1927" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SSV Jahn Regensburg</span>
                         <span class="cat-country-meta">13 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/1061.html" class="cat-country-card" title="SSV Reutlingen 05">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1061%2F1751115504847_IMG_6080_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1061%2F1751115504847_IMG_6080_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2372" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SSV Reutlingen 05</span>
                         <span class="cat-country-meta">2 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/950.html" class="cat-country-card" title="SSV Ulm 1846">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SSV_Ulm_1846/IMG_2068_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SSV_Ulm_1846/IMG_2068_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1877" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SSV Ulm 1846</span>
                         <span class="cat-country-meta">3 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/916.html" class="cat-country-card" title="Stuttgarter Kickers">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Stuttgarter_Kickers/IMG_0882_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Stuttgarter_Kickers/IMG_0882_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1566" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Stuttgarter Kickers</span>
                         <span class="cat-country-meta">4 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/873.html" class="cat-country-card" title="SV Babelsberg 03">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_Babelsberg_03/IMG_7895_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_Babelsberg_03/IMG_7895_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1298" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SV Babelsberg 03</span>
                         <span class="cat-country-meta">2 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/858.html" class="cat-country-card" title="SV Ballern">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Ballern/IMG_1893_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Ballern/IMG_1893_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1252" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SV Ballern</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/1054.html" class="cat-country-card" title="SV Bekond">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1054%2F1749911157460_IMG_5941_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1054%2F1749911157460_IMG_5941_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2323" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SV Bekond</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/1074.html" class="cat-country-card" title="SV Botan Köln 1988">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1074%2F1755812121186_IMG_6195_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1074%2F1755812121186_IMG_6195_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2437" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SV Botan Köln 1988</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/853.html" class="cat-country-card" title="sv Ebersbach">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Ebersbach/IMG_7113_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Ebersbach/IMG_7113_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1202" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 sv Ebersbach</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/1149.html" class="cat-country-card" title="SV Eintracht Trier 05">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1149/1769890877252_IMG_7919_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1149/1769890877252_IMG_7919_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2939" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SV Eintracht Trier 05</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/917.html" class="cat-country-card" title="SV Emmerke 1909">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_Emmerke_1909/IMG_1962_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_Emmerke_1909/IMG_1962_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1568" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SV Emmerke 1909</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/966.html" class="cat-country-card" title="SV Heimstetten">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_Heimstetten/IMG_1087_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_Heimstetten/IMG_1087_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1936" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SV Heimstetten</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/867.html" class="cat-country-card" title="sv Kell">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Kell/IMG_7714_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Kell/IMG_7714_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1286" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 sv Kell</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/862.html" class="cat-country-card" title="SV Krechting">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_Krechting/IMG_1419_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_Krechting/IMG_1419_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1271" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SV Krechting</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/911.html" class="cat-country-card" title="SV Lippstadt 08">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_Lippstadt_08/IMG_0059_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_Lippstadt_08/IMG_0059_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1549" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SV Lippstadt 08</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/1141.html" class="cat-country-card" title="SV Meppen">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1141/1766183741223_IMG_7618_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1141/1766183741223_IMG_7618_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2811" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SV Meppen</span>
                         <span class="cat-country-meta">2 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/898.html" class="cat-country-card" title="SV Ochtendung">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_Ochtendung/IMG_1128_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_Ochtendung/IMG_1128_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1515" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SV Ochtendung</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/854.html" class="cat-country-card" title="SV Rot-Weiss Merzdorf">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_Rot-Weiss_Merzdorf/IMG_9627_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_Rot-Weiss_Merzdorf/IMG_9627_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1203" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SV Rot-Weiss Merzdorf</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/951.html" class="cat-country-card" title="SV st Maergen eV">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_st_Maergen_eV/IMG_0659_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_st_Maergen_eV/IMG_0659_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1879" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SV st Maergen eV</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/899.html" class="cat-country-card" title="SV St Stephan 1953 Griesheim eV">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_St_Stephan_1953_Griesheim_eV/IMG_0930_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_St_Stephan_1953_Griesheim_eV/IMG_0930_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1516" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SV St Stephan 1953 Griesheim eV</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/941.html" class="cat-country-card" title="sv Union Bestensee">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/sv_Union_Bestensee/IMG_1918_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/sv_Union_Bestensee/IMG_1918_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1775" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 sv Union Bestensee</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/894.html" class="cat-country-card" title="SV Waldhof Mannheim">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_Waldhof_Mannheim/IMG_9279_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_Waldhof_Mannheim/IMG_9279_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1437" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SV Waldhof Mannheim</span>
                         <span class="cat-country-meta">12 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/902.html" class="cat-country-card" title="SV Wehen Wiesbaden">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_902%2F1746796749814_IMG_5327_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_902%2F1746796749814_IMG_5327_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2228" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SV Wehen Wiesbaden</span>
                         <span class="cat-country-meta">2 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/860.html" class="cat-country-card" title="SV Werder Bremen">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_Werder_Bremen/IMG_1364_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_Werder_Bremen/IMG_1364_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1261" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SV Werder Bremen</span>
                         <span class="cat-country-meta">21 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/878.html" class="cat-country-card" title="SV Zehdenick 1920 eV">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_Zehdenick_1920_eV/IMG_9452_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SV_Zehdenick_1920_eV/IMG_9452_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1317" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SV Zehdenick 1920 eV</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/1076.html" class="cat-country-card" title="SV Zeltingen-Rachtig">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1076%2F1755812616539_IMG_6178_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1076%2F1755812616539_IMG_6178_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2442" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 SV Zeltingen-Rachtig</span>
                         <span class="cat-country-meta">3 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/859.html" class="cat-country-card" title="T u S Pewsum eV von 1863">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/T_u_S_Pewsum_eV_von_1863/IMG_0553_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/T_u_S_Pewsum_eV_von_1863/IMG_0553_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1253" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 T u S Pewsum eV von 1863</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/1070.html" class="cat-country-card" title="TB Ruit 1892 e.V.">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1070%2F1755810972825_IMG_6229_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1070%2F1755810972825_IMG_6229_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2420" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 TB Ruit 1892 e.V.</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/939.html" class="cat-country-card" title="TSG 1899 Hoffenheim">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TSG_1899_Hoffenheim/IMG_4919_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TSG_1899_Hoffenheim/IMG_4919_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1772" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 TSG 1899 Hoffenheim</span>
                         <span class="cat-country-meta">3 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/896.html" class="cat-country-card" title="TSV 1860 München">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TSV_1860_Munchen/IMG_1173_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TSV_1860_Munchen/IMG_1173_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1489" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 TSV 1860 München</span>
                         <span class="cat-country-meta">61 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/875.html" class="cat-country-card" title="TSV Dagersheim">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TSV_Dagersheim/IMG_0661_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TSV_Dagersheim/IMG_0661_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1301" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 TSV Dagersheim</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/944.html" class="cat-country-card" title="TSV Eschenbach">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TSV_Eschenbach/IMG_0811_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TSV_Eschenbach/IMG_0811_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1778" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 TSV Eschenbach</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/918.html" class="cat-country-card" title="TSV Olympia Eisenbach">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TSV_Olympia_Eisenbach/IMG_3495_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TSV_Olympia_Eisenbach/IMG_3495_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1569" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 TSV Olympia Eisenbach</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/932.html" class="cat-country-card" title="TSV Ottenstein">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TSV_Ottenstein/IMG_9307_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TSV_Ottenstein/IMG_9307_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1748" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 TSV Ottenstein</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/909.html" class="cat-country-card" title="TSV Schmölz">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TSV_Schmolz/IMG_1107_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TSV_Schmolz/IMG_1107_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1545" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 TSV Schmölz</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/1060.html" class="cat-country-card" title="TSV Unterschüpf 1902">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1060%2F1751115215387_IMG_6071_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1060%2F1751115215387_IMG_6071_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2371" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 TSV Unterschüpf 1902</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/855.html" class="cat-country-card" title="TUS Hiltrup">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TUS_Hiltrup/IMG_7718_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TUS_Hiltrup/IMG_7718_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1204" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 TUS Hiltrup</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/929.html" class="cat-country-card" title="TuS Homburg-Bröltal">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TuS_Homburg-Broltal/IMG_9956_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TuS_Homburg-Broltal/IMG_9956_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1721" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 TuS Homburg-Bröltal</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/933.html" class="cat-country-card" title="TuS Koblenz">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_933/1769941933458_IMG_7930_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_933/1769941933458_IMG_7930_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2980" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 TuS Koblenz</span>
                         <span class="cat-country-meta">2 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/1135.html" class="cat-country-card" title="TuS Köln rrh.">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1135/1763895674934_IMG_7470_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1135/1763895674934_IMG_7470_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2763" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 TuS Köln rrh.</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/882.html" class="cat-country-card" title="TV Rönkhausen 1892 eV">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TV_Ronkhausen_1892_eV/IMG_1122_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/TV_Ronkhausen_1892_eV/IMG_1122_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1416" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 TV Rönkhausen 1892 eV</span>
                         <span class="cat-country-meta">2 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/970.html" class="cat-country-card" title="VfB Oberndorf eV">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/VfB_Oberndorf_eV/IMG_1381_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/VfB_Oberndorf_eV/IMG_1381_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1948" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 VfB Oberndorf eV</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/958.html" class="cat-country-card" title="VfB Oldenburg">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/VfB_Oldenburg/IMG_1116_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/VfB_Oldenburg/IMG_1116_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1898" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 VfB Oldenburg</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/947.html" class="cat-country-card" title="VfB Stuttgart">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_947%2F1751114262225_IMG_6075_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_947%2F1751114262225_IMG_6075_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2362" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 VfB Stuttgart</span>
                         <span class="cat-country-meta">64 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/1130.html" class="cat-country-card" title="VfB Zwenkau">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1130/1763673898896_IMG_7431_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1130/1763673898896_IMG_7431_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2739" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 VfB Zwenkau</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/886.html" class="cat-country-card" title="VfL Bochum">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/VfL_Bochum/IMG_1162_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/VfL_Bochum/IMG_1162_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1424" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 VfL Bochum</span>
                         <span class="cat-country-meta">12 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/907.html" class="cat-country-card" title="Vfl Borsum">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Vfl_Borsum/IMG_9613_(1)_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Vfl_Borsum/IMG_9613_(1)_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1542" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Vfl Borsum</span>
                         <span class="cat-country-meta">2 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/968.html" class="cat-country-card" title="Vfl Osnabrück">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Vfl_Osnabruck/IMG_8088_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Vfl_Osnabruck/IMG_8088_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1942" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Vfl Osnabrück</span>
                         <span class="cat-country-meta">11 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/931.html" class="cat-country-card" title="VfL Wolfsburg">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_931/1759592590153_IMG_7227_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_931/1759592590153_IMG_7227_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2623" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 VfL Wolfsburg</span>
                         <span class="cat-country-meta">3 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/872.html" class="cat-country-card" title="Wacker Munchen">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Wacker_Munchen/IMG_5802_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Wacker_Munchen/IMG_5802_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1297" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Wacker Munchen</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/905.html" class="cat-country-card" title="Wormatia Worms">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_905%2F1746748907001_IMG_5324_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_905%2F1746748907001_IMG_5324_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2133" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Wormatia Worms</span>
                         <span class="cat-country-meta">2 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/938.html" class="cat-country-card" title="Würzburger Kickers">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Wurzburger_Kickers/IMG_0909_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Wurzburger_Kickers/IMG_0909_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="1769" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇩🇪 Würzburger Kickers</span>
                         <span class="cat-country-meta">8 stickers</span>

--- a/countries/NOR.html
+++ b/countries/NOR.html
@@ -246,42 +246,42 @@
             </div>
             <div class="cat-clubs-strip">
                 <a href="/clubs/624.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SK_Brann/IMG_9740_thumb.webp" alt="SK Brann sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SK_Brann/IMG_9740_thumb.webp" alt="SK Brann sticker" data-sticker-id="335" loading="lazy" decoding="async">
                     <span class="cat-club-label">SK Brann</span>
                     <span class="cat-club-count">7 stickers</span>
                 </a>
                 <a href="/clubs/626.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_626%2F1749293462098_IMG_5610_thumb.webp" alt="Vålerenga Fotball sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_626%2F1749293462098_IMG_5610_thumb.webp" alt="Vålerenga Fotball sticker" data-sticker-id="2300" loading="lazy" decoding="async">
                     <span class="cat-club-label">Vålerenga Fotball</span>
                     <span class="cat-club-count">4 stickers</span>
                 </a>
                 <a href="/clubs/67.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Stromsgodset_Toppfotball/IMG_3034_thumb.webp" alt="Stromsgodset Toppfotball sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Stromsgodset_Toppfotball/IMG_3034_thumb.webp" alt="Stromsgodset Toppfotball sticker" data-sticker-id="282" loading="lazy" decoding="async">
                     <span class="cat-club-label">Stromsgodset Toppfotball</span>
                     <span class="cat-club-count">3 stickers</span>
                 </a>
                 <a href="/clubs/617.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Bodo_glimt/IMG_5675_thumb.webp" alt="Bodo glimt sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Bodo_glimt/IMG_5675_thumb.webp" alt="Bodo glimt sticker" data-sticker-id="311" loading="lazy" decoding="async">
                     <span class="cat-club-label">Bodo glimt</span>
                     <span class="cat-club-count">2 stickers</span>
                 </a>
                 <a href="/clubs/625.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_625/1773521327297_IMG_8331_thumb.webp" alt="Viking FK Stavanger sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_625/1773521327297_IMG_8331_thumb.webp" alt="Viking FK Stavanger sticker" data-sticker-id="3084" loading="lazy" decoding="async">
                     <span class="cat-club-label">Viking FK Stavanger</span>
                     <span class="cat-club-count">2 stickers</span>
                 </a>
                 <a href="/clubs/1081.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1081%2F1757193836227_IMG_6771_thumb.webp" alt="Aalesunds FK sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1081%2F1757193836227_IMG_6771_thumb.webp" alt="Aalesunds FK sticker" data-sticker-id="2509" loading="lazy" decoding="async">
                     <span class="cat-club-label">Aalesunds FK</span>
                     <span class="cat-club-count">1 sticker</span>
                 </a>
                 <a href="/clubs/623.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FK_Haugesund/IMG_1420_thumb.webp" alt="FK Haugesund sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FK_Haugesund/IMG_1420_thumb.webp" alt="FK Haugesund sticker" data-sticker-id="334" loading="lazy" decoding="async">
                     <span class="cat-club-label">FK Haugesund</span>
                     <span class="cat-club-count">1 sticker</span>
                 </a>
                 <a href="/clubs/619.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Hamarkameratene/IMG_1799_thumb.webp" alt="Hamarkameratene sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Hamarkameratene/IMG_1799_thumb.webp" alt="Hamarkameratene sticker" data-sticker-id="315" loading="lazy" decoding="async">
                     <span class="cat-club-label">Hamarkameratene</span>
                     <span class="cat-club-count">1 sticker</span>
                 </a></div>
@@ -297,119 +297,119 @@
             <div class="cat-country-grid">
                 
                 <a href="/clubs/1081.html" class="cat-country-card" title="Aalesunds FK">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1081%2F1757193836227_IMG_6771_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1081%2F1757193836227_IMG_6771_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2509" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇳🇴 Aalesunds FK</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/617.html" class="cat-country-card" title="Bodo glimt">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Bodo_glimt/IMG_5675_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Bodo_glimt/IMG_5675_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="311" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇳🇴 Bodo glimt</span>
                         <span class="cat-country-meta">2 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/623.html" class="cat-country-card" title="FK Haugesund">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FK_Haugesund/IMG_1420_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FK_Haugesund/IMG_1420_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="334" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇳🇴 FK Haugesund</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/619.html" class="cat-country-card" title="Hamarkameratene">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Hamarkameratene/IMG_1799_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Hamarkameratene/IMG_1799_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="315" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇳🇴 Hamarkameratene</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/1116.html" class="cat-country-card" title="IK Start">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1116/1760189924448_IMG_7313_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1116/1760189924448_IMG_7313_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2684" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇳🇴 IK Start</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/105.html" class="cat-country-card" title="Lyn 1896 FK">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Lyn_1896_FK/IMG_1372_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Lyn_1896_FK/IMG_1372_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="362" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇳🇴 Lyn 1896 FK</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/1115.html" class="cat-country-card" title="Moss FK">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1115/1760126758430_IMG_7296_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1115/1760126758430_IMG_7296_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2671" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇳🇴 Moss FK</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/629.html" class="cat-country-card" title="Odds">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Odds/IMG_7304_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Odds/IMG_7304_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="363" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇳🇴 Odds</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/1184.html" class="cat-country-card" title="Reinsvoll IF">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1184/1776079772611_IMG_9408_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1184/1776079772611_IMG_9408_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="3315" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇳🇴 Reinsvoll IF</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/1052.html" class="cat-country-card" title="Rosenborg BK">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1052%2F1749293676367_IMG_5869_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1052%2F1749293676367_IMG_5869_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2303" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇳🇴 Rosenborg BK</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/1029.html" class="cat-country-card" title="Sarpsborg 08 FF">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1029%2F1746721794532_IMG_5226_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1029%2F1746721794532_IMG_5226_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2111" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇳🇴 Sarpsborg 08 FF</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/624.html" class="cat-country-card" title="SK Brann">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SK_Brann/IMG_9740_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/SK_Brann/IMG_9740_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="335" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇳🇴 SK Brann</span>
                         <span class="cat-country-meta">7 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/608.html" class="cat-country-card" title="Stabæk Fotball">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_608%2F1746523504076_IMG_0466_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_608%2F1746523504076_IMG_0466_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="405" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇳🇴 Stabæk Fotball</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/67.html" class="cat-country-card" title="Stromsgodset Toppfotball">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Stromsgodset_Toppfotball/IMG_3034_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Stromsgodset_Toppfotball/IMG_3034_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="282" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇳🇴 Stromsgodset Toppfotball</span>
                         <span class="cat-country-meta">3 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/613.html" class="cat-country-card" title="Tromsø IL">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_613%2F1746523533043_IMG_0853_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_613%2F1746523533043_IMG_0853_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="406" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇳🇴 Tromsø IL</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/626.html" class="cat-country-card" title="Vålerenga Fotball">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_626%2F1749293462098_IMG_5610_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_626%2F1749293462098_IMG_5610_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="2300" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇳🇴 Vålerenga Fotball</span>
                         <span class="cat-country-meta">4 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/625.html" class="cat-country-card" title="Viking FK Stavanger">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_625/1773521327297_IMG_8331_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_625/1773521327297_IMG_8331_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="3084" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇳🇴 Viking FK Stavanger</span>
                         <span class="cat-country-meta">2 stickers</span>

--- a/countries/ROU.html
+++ b/countries/ROU.html
@@ -32,7 +32,7 @@
     <meta property="og:url" content="https://stickerhunt.club/countries/ROU.html">
     <meta property="og:title" content="Romania Football Stickers — 9 Clubs, 25 Stickers | StickerHunt">
     <meta property="og:description" content="Browse 25 football stickers from 9 clubs in Romania. Find stickers from Romania clubs in the StickerHunt database.">
-    <meta property="og:image" content="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FCSB/IMG_0518_web.webp">
+    <meta property="og:image" content="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_614/1777110800517_IMG_9613_web.webp">
     <meta property="og:site_name" content="StickerHunt">
 
     <!-- Twitter -->
@@ -40,7 +40,7 @@
     <meta property="twitter:url" content="https://stickerhunt.club/countries/ROU.html">
     <meta property="twitter:title" content="Romania Football Stickers — 9 Clubs, 25 Stickers | StickerHunt">
     <meta property="twitter:description" content="Browse 25 football stickers from 9 clubs in Romania. Find stickers from Romania clubs in the StickerHunt database.">
-    <meta property="twitter:image" content="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FCSB/IMG_0518_web.webp">
+    <meta property="twitter:image" content="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_614/1777110800517_IMG_9613_web.webp">
     <meta property="twitter:site" content="@StickerHunting">
     <meta property="twitter:creator" content="@StickerHunting">
 
@@ -198,42 +198,42 @@
             </div>
             <div class="cat-clubs-strip">
                 <a href="/clubs/614.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FCSB/IMG_0518_thumb.webp" alt="FCSB sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_614/1777110800517_IMG_9613_thumb.webp" alt="FCSB sticker" data-sticker-id="3378" loading="lazy" decoding="async">
                     <span class="cat-club-label">FCSB</span>
                     <span class="cat-club-count">8 stickers</span>
                 </a>
                 <a href="/clubs/633.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/CS_Universitatea_Craiova/IMG_8916_thumb.webp" alt="CS Universitatea Craiova sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/CS_Universitatea_Craiova/IMG_8916_thumb.webp" alt="CS Universitatea Craiova sticker" data-sticker-id="378" loading="lazy" decoding="async">
                     <span class="cat-club-label">CS Universitatea Craiova</span>
                     <span class="cat-club-count">5 stickers</span>
                 </a>
                 <a href="/clubs/637.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Rapid_Bucuresti/IMG_7518_thumb.webp" alt="Rapid Bucuresti sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Rapid_Bucuresti/IMG_7518_thumb.webp" alt="Rapid Bucuresti sticker" data-sticker-id="386" loading="lazy" decoding="async">
                     <span class="cat-club-label">Rapid Bucuresti</span>
                     <span class="cat-club-count">3 stickers</span>
                 </a>
                 <a href="/clubs/22.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Corvinul_Hunedoara/IMG_4170_thumb.webp" alt="FC Corvinul Hunedoara sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Corvinul_Hunedoara/IMG_4170_thumb.webp" alt="FC Corvinul Hunedoara sticker" data-sticker-id="298" loading="lazy" decoding="async">
                     <span class="cat-club-label">FC Corvinul Hunedoara</span>
                     <span class="cat-club-count">2 stickers</span>
                 </a>
                 <a href="/clubs/618.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Dinamo_Bucuresti/IMG_8397_(1)_thumb.webp" alt="FC Dinamo București sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Dinamo_Bucuresti/IMG_8397_(1)_thumb.webp" alt="FC Dinamo București sticker" data-sticker-id="313" loading="lazy" decoding="async">
                     <span class="cat-club-label">FC Dinamo București</span>
                     <span class="cat-club-count">2 stickers</span>
                 </a>
                 <a href="/clubs/646.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Politehnica_Iasi/IMG_8511_thumb.webp" alt="FC Politehnica Iași sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Politehnica_Iasi/IMG_8511_thumb.webp" alt="FC Politehnica Iași sticker" data-sticker-id="403" loading="lazy" decoding="async">
                     <span class="cat-club-label">FC Politehnica Iași</span>
                     <span class="cat-club-count">2 stickers</span>
                 </a>
                 <a href="/clubs/628.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/CSM_Resita/IMG_3716_thumb.webp" alt="CSM Reșița sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/CSM_Resita/IMG_3716_thumb.webp" alt="CSM Reșița sticker" data-sticker-id="347" loading="lazy" decoding="async">
                     <span class="cat-club-label">CSM Reșița</span>
                     <span class="cat-club-count">1 sticker</span>
                 </a>
                 <a href="/clubs/643.html" class="cat-club-card">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Politehnica_Timisoara/IMG_9547_(5)_thumb.webp" alt="FC Politehnica Timișoara sticker" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Politehnica_Timisoara/IMG_9547_(5)_thumb.webp" alt="FC Politehnica Timișoara sticker" data-sticker-id="397" loading="lazy" decoding="async">
                     <span class="cat-club-label">FC Politehnica Timișoara</span>
                     <span class="cat-club-count">1 sticker</span>
                 </a></div>
@@ -249,63 +249,63 @@
             <div class="cat-country-grid">
                 
                 <a href="/clubs/633.html" class="cat-country-card" title="CS Universitatea Craiova">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/CS_Universitatea_Craiova/IMG_8916_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/CS_Universitatea_Craiova/IMG_8916_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="378" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇷🇴 CS Universitatea Craiova</span>
                         <span class="cat-country-meta">5 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/628.html" class="cat-country-card" title="CSM Reșița">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/CSM_Resita/IMG_3716_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/CSM_Resita/IMG_3716_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="347" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇷🇴 CSM Reșița</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/22.html" class="cat-country-card" title="FC Corvinul Hunedoara">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Corvinul_Hunedoara/IMG_4170_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Corvinul_Hunedoara/IMG_4170_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="298" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇷🇴 FC Corvinul Hunedoara</span>
                         <span class="cat-country-meta">2 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/618.html" class="cat-country-card" title="FC Dinamo București">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Dinamo_Bucuresti/IMG_8397_(1)_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Dinamo_Bucuresti/IMG_8397_(1)_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="313" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇷🇴 FC Dinamo București</span>
                         <span class="cat-country-meta">2 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/646.html" class="cat-country-card" title="FC Politehnica Iași">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Politehnica_Iasi/IMG_8511_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Politehnica_Iasi/IMG_8511_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="403" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇷🇴 FC Politehnica Iași</span>
                         <span class="cat-country-meta">2 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/643.html" class="cat-country-card" title="FC Politehnica Timișoara">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Politehnica_Timisoara/IMG_9547_(5)_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Politehnica_Timisoara/IMG_9547_(5)_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="397" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇷🇴 FC Politehnica Timișoara</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/642.html" class="cat-country-card" title="FC UTA Arad">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_UTA_Arad/IMG_0702_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_UTA_Arad/IMG_0702_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="396" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇷🇴 FC UTA Arad</span>
                         <span class="cat-country-meta">1 sticker</span>
                     </div>
                 </a>
                 <a href="/clubs/614.html" class="cat-country-card" title="FCSB">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FCSB/IMG_0518_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_614/1777110800517_IMG_9613_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="3378" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇷🇴 FCSB</span>
                         <span class="cat-country-meta">8 stickers</span>
                     </div>
                 </a>
                 <a href="/clubs/637.html" class="cat-country-card" title="Rapid Bucuresti">
-                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Rapid_Bucuresti/IMG_7518_thumb.webp" class="country-club-thumb" alt="" loading="lazy" decoding="async">
+                    <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Rapid_Bucuresti/IMG_7518_thumb.webp" class="country-club-thumb" alt="" data-sticker-id="386" loading="lazy" decoding="async">
                     <div class="cat-country-info">
                         <span class="cat-country-name">🇷🇴 Rapid Bucuresti</span>
                         <span class="cat-country-meta">3 stickers</span>

--- a/js/view-tracker.js
+++ b/js/view-tracker.js
@@ -28,17 +28,10 @@
         : null;
 
     function isBadgePage(path) {
-        if (/^\/(?:quiz|battle)\.html$/i.test(path)) {
-            return false;
-        }
-
-        return path === '/'
-            || path === '/index.html'
-            || path === '/catalogue.html'
-            || /^\/clubs\/\d+\.html$/i.test(path)
-            || /^\/countries\/[a-z]{3}\.html$/i.test(path)
-            || /^\/cities\/(?!index\.html$)[^/]+\.html$/i.test(path)
-            || /^\/stickers\/\d+\.html$/i.test(path);
+        // Badge is rendered only on the single sticker page. Tracking still
+        // fires everywhere else (catalogue, club, country, city, homepage,
+        // quiz, battle) — only the visual counter is scoped to /stickers/{id}.
+        return /^\/stickers\/\d+\.html$/i.test(path);
     }
 
     function loadSeenStickerIds() {

--- a/stickers/2332.html
+++ b/stickers/2332.html
@@ -8,7 +8,7 @@
 
     <!-- SEO Meta Tags - Pre-rendered for better indexing -->
     <meta name="description" content="Football sticker #2332 from Djurgardens IF, Sweden. Can you identify this Djurgardens IF sticker? Browse our collection.">
-    <meta name="keywords" content="football stickers, 🇸🇪 Djurgardens IF, Sweden, panini, sticker collection, Djurgården DIF DjurgårdensIF TifosiDIF Allsvenskan">
+    <meta name="keywords" content="Djurgardens IF stickers, Djurgardens IF football stickers, identify Djurgardens IF sticker, Sweden football stickers, football sticker database, Djurg, DIF, Djurg, TifosiDIF, Allsvenskan">
     <link rel="canonical" href="https://stickerhunt.club/stickers/2332.html">
     
     <meta name="description" lang="de" content="Djurgardens IF Fussball-Sticker #2332 -- kannst du ihn identifizieren? StickerHunt.">
@@ -146,10 +146,11 @@
                         <div class="sticker-detail-image-container" onclick="window.open('https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_749%2F1749912243096_IMG_5997.jpeg', '_blank')">
                             <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_749%2F1749912243096_IMG_5997_web.webp"
                                  alt="Djurgardens IF football sticker -- from Prague, Sweden -- #2332"
+                                 data-sticker-id="2332"
                                  class="sticker-detail-image"
                                  decoding="async"
                                  loading="eager"
-                                 fetchpriority="high" data-sticker-id="2332">
+                                 fetchpriority="high">
                         </div>
                         <div class="sticker-nav-buttons"><a href="/stickers/2331.html" class="btn btn-nav sticker-nav-btn">← #2331</a><a href="/stickers/2333.html" class="btn btn-nav sticker-nav-btn">#2333 →</a></div>
                     </div>
@@ -201,12 +202,12 @@
                 <div class="more-from-club">
 <h3>More from Djurgardens IF</h3>
 <div class="sticker-strip">
-<a href="/stickers/765.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Djurgardens_IF/IMG_3064_thumb.webp?" alt="Sticker #765" loading="lazy" decoding="async" data-sticker-id="765"></a>
-<a href="/stickers/766.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Djurgardens_IF/IMG_9310_thumb.webp?" alt="Sticker #766" loading="lazy" decoding="async" data-sticker-id="766"></a>
-<a href="/stickers/767.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Djurgardens_IF/IMG_7732_thumb.webp?" alt="Sticker #767" loading="lazy" decoding="async" data-sticker-id="767"></a>
-<a href="/stickers/768.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Djurgardens_IF/IMG_9254_thumb.webp?" alt="Sticker #768" loading="lazy" decoding="async" data-sticker-id="768"></a>
-<a href="/stickers/769.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Djurgardens_IF/IMG_3557_thumb.webp?" alt="Sticker #769" loading="lazy" decoding="async" data-sticker-id="769"></a>
-<a href="/stickers/770.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Djurgardens_IF/IMG_7810_thumb.webp?" alt="Sticker #770" loading="lazy" decoding="async" data-sticker-id="770"></a>
+<a href="/stickers/765.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Djurgardens_IF/IMG_3064_thumb.webp?" alt="Sticker #765" data-sticker-id="765" loading="lazy" decoding="async"></a>
+<a href="/stickers/766.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Djurgardens_IF/IMG_9310_thumb.webp?" alt="Sticker #766" data-sticker-id="766" loading="lazy" decoding="async"></a>
+<a href="/stickers/767.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Djurgardens_IF/IMG_7732_thumb.webp?" alt="Sticker #767" data-sticker-id="767" loading="lazy" decoding="async"></a>
+<a href="/stickers/768.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Djurgardens_IF/IMG_9254_thumb.webp?" alt="Sticker #768" data-sticker-id="768" loading="lazy" decoding="async"></a>
+<a href="/stickers/769.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Djurgardens_IF/IMG_3557_thumb.webp?" alt="Sticker #769" data-sticker-id="769" loading="lazy" decoding="async"></a>
+<a href="/stickers/770.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Djurgardens_IF/IMG_7810_thumb.webp?" alt="Sticker #770" data-sticker-id="770" loading="lazy" decoding="async"></a>
 </div>
 </div>
                 
@@ -216,12 +217,12 @@
                 <div class="nearby-stickers-section">
 <h3>Also found in Prague</h3>
 <div class="sticker-strip">
-<a href="/stickers/2313.html" class="sticker-strip-item" title="🇩🇪 1 FC Union Berlin"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_945%2F1749910575342_IMG_5979_thumb.webp" alt="🇩🇪 1 FC Union Berlin" loading="lazy" decoding="async" data-sticker-id="2313"></a>
-<a href="/stickers/2312.html" class="sticker-strip-item" title="🇫🇷 Lille OSC"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_676%2F1749910551891_IMG_5980_thumb.webp" alt="🇫🇷 Lille OSC" loading="lazy" decoding="async" data-sticker-id="2312"></a>
-<a href="/stickers/2315.html" class="sticker-strip-item" title="🇩🇪 FC St Pauli"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_881%2F1749910838666_IMG_5955_thumb.webp" alt="🇩🇪 FC St Pauli" loading="lazy" decoding="async" data-sticker-id="2315"></a>
-<a href="/stickers/2311.html" class="sticker-strip-item" title="🇩🇪 Hannover 96"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_877%2F1749910520324_IMG_5978_thumb.webp" alt="🇩🇪 Hannover 96" loading="lazy" decoding="async" data-sticker-id="2311"></a>
-<a href="/stickers/2331.html" class="sticker-strip-item" title="🇩🇪 1 FC Köln"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_937%2F1749912217937_IMG_5999_thumb.webp" alt="🇩🇪 1 FC Köln" loading="lazy" decoding="async" data-sticker-id="2331"></a>
-<a href="/stickers/2320.html" class="sticker-strip-item" title="🇨🇿 FK Viktoria Žižkov"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1041%2F1749910993659_IMG_5961_thumb.webp" alt="🇨🇿 FK Viktoria Žižkov" loading="lazy" decoding="async" data-sticker-id="2320"></a>
+<a href="/stickers/2313.html" class="sticker-strip-item" title="🇩🇪 1 FC Union Berlin"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_945%2F1749910575342_IMG_5979_thumb.webp" alt="🇩🇪 1 FC Union Berlin" data-sticker-id="2313" loading="lazy" decoding="async"></a>
+<a href="/stickers/2312.html" class="sticker-strip-item" title="🇫🇷 Lille OSC"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_676%2F1749910551891_IMG_5980_thumb.webp" alt="🇫🇷 Lille OSC" data-sticker-id="2312" loading="lazy" decoding="async"></a>
+<a href="/stickers/2315.html" class="sticker-strip-item" title="🇩🇪 FC St Pauli"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_881%2F1749910838666_IMG_5955_thumb.webp" alt="🇩🇪 FC St Pauli" data-sticker-id="2315" loading="lazy" decoding="async"></a>
+<a href="/stickers/2311.html" class="sticker-strip-item" title="🇩🇪 Hannover 96"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_877%2F1749910520324_IMG_5978_thumb.webp" alt="🇩🇪 Hannover 96" data-sticker-id="2311" loading="lazy" decoding="async"></a>
+<a href="/stickers/2331.html" class="sticker-strip-item" title="🇩🇪 1 FC Köln"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_937%2F1749912217937_IMG_5999_thumb.webp" alt="🇩🇪 1 FC Köln" data-sticker-id="2331" loading="lazy" decoding="async"></a>
+<a href="/stickers/2320.html" class="sticker-strip-item" title="🇨🇿 FK Viktoria Žižkov"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_1041%2F1749910993659_IMG_5961_thumb.webp" alt="🇨🇿 FK Viktoria Žižkov" data-sticker-id="2320" loading="lazy" decoding="async"></a>
 </div>
 </div>
             </div>
@@ -336,19 +337,6 @@
                         opacity: 0.6
                     }).addTo(map)
                     .bindPopup('<div class="nearby-sticker-popup"><strong>FK Viktoria Žižkov</strong><a href="/stickers/2320.html" class="map-popup-link">View</a></div>');
-                })();
-
-                (function() {
-                    L.marker([50.0911638888889, 14.4272305555556], {
-                        icon: L.icon({
-                            iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
-                            iconSize: [18, 30],
-                            iconAnchor: [9, 30],
-                            popupAnchor: [1, -25]
-                        }),
-                        opacity: 0.6
-                    }).addTo(map)
-                    .bindPopup('<div class="nearby-sticker-popup"><strong>1 FC Magdeburg</strong><a href="/stickers/2328.html" class="map-popup-link">View</a></div>');
                 })();
 
                 (function() {
@@ -690,19 +678,6 @@
                 })();
 
                 (function() {
-                    L.marker([50.0774388888889, 14.4204083333333], {
-                        icon: L.icon({
-                            iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
-                            iconSize: [18, 30],
-                            iconAnchor: [9, 30],
-                            popupAnchor: [1, -25]
-                        }),
-                        opacity: 0.6
-                    }).addTo(map)
-                    .bindPopup('<div class="nearby-sticker-popup"><strong>Hansa Rostock</strong><a href="/stickers/2462.html" class="map-popup-link">View</a></div>');
-                })();
-
-                (function() {
                     L.marker([50.0774611111111, 14.4258916666667], {
                         icon: L.icon({
                             iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
@@ -937,19 +912,6 @@
                 })();
 
                 (function() {
-                    L.marker([50.0882027777778, 14.4477944444444], {
-                        icon: L.icon({
-                            iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
-                            iconSize: [18, 30],
-                            iconAnchor: [9, 30],
-                            popupAnchor: [1, -25]
-                        }),
-                        opacity: 0.6
-                    }).addTo(map)
-                    .bindPopup('<div class="nearby-sticker-popup"><strong>Nantes</strong><a href="/stickers/2318.html" class="map-popup-link">View</a></div>');
-                })();
-
-                (function() {
                     L.marker([50.0905333333333, 14.46045], {
                         icon: L.icon({
                             iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
@@ -1105,6 +1067,45 @@
                     .bindPopup('<div class="nearby-sticker-popup"><strong>Galatasaray</strong><a href="/stickers/2454.html" class="map-popup-link">View</a></div>');
                 })();
 
+                (function() {
+                    L.marker([50.0882027777778, 14.4477944444444], {
+                        icon: L.icon({
+                            iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+                            iconSize: [18, 30],
+                            iconAnchor: [9, 30],
+                            popupAnchor: [1, -25]
+                        }),
+                        opacity: 0.6
+                    }).addTo(map)
+                    .bindPopup('<div class="nearby-sticker-popup"><strong>Nantes</strong><a href="/stickers/2318.html" class="map-popup-link">View</a></div>');
+                })();
+
+                (function() {
+                    L.marker([50.0911638888889, 14.4272305555556], {
+                        icon: L.icon({
+                            iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+                            iconSize: [18, 30],
+                            iconAnchor: [9, 30],
+                            popupAnchor: [1, -25]
+                        }),
+                        opacity: 0.6
+                    }).addTo(map)
+                    .bindPopup('<div class="nearby-sticker-popup"><strong>1 FC Magdeburg</strong><a href="/stickers/2328.html" class="map-popup-link">View</a></div>');
+                })();
+
+                (function() {
+                    L.marker([50.0774388888889, 14.4204083333333], {
+                        icon: L.icon({
+                            iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+                            iconSize: [18, 30],
+                            iconAnchor: [9, 30],
+                            popupAnchor: [1, -25]
+                        }),
+                        opacity: 0.6
+                    }).addTo(map)
+                    .bindPopup('<div class="nearby-sticker-popup"><strong>Hansa Rostock</strong><a href="/stickers/2462.html" class="map-popup-link">View</a></div>');
+                })();
+
                 // Current sticker — larger marker, opened popup
                 L.marker([50.087775, 14.39005], {
                     icon: L.icon({
@@ -1129,7 +1130,6 @@
                     [50.0709222222222, 14.4151722222222],
                     [50.0972583333333, 14.4636611111111],
                     [50.0887638888889, 14.4612861111111],
-                    [50.0911638888889, 14.4272305555556],
                     [50.0876777777778, 14.390175],
                     [50.0876805555556, 14.3912305555556],
                     [50.0916111111111, 14.4489305555556],
@@ -1156,7 +1156,6 @@
                     [50.0773805555556, 14.423675],
                     [50.0775027777778, 14.4204694444444],
                     [50.0779305555556, 14.4195166666667],
-                    [50.0774388888889, 14.4204083333333],
                     [50.0774611111111, 14.4258916666667],
                     [50.0845555555556, 14.4135694444444],
                     [50.0782361111111, 14.4191444444444],
@@ -1172,7 +1171,9 @@
                     [50.0881888888889, 14.4477583333333],
                     [50.0911972222222, 14.4271972222222],
                     [50.0903166666667, 14.45905],
-                    [50.0918833333333, 14.4263916666667]
+                    [50.0918833333333, 14.4263916666667],
+                    [50.078025, 14.4178972222222],
+                    [50.0801083333333, 14.4279111111111]
                 ]);
                 map.fitBounds(bounds, { padding: [30, 30], maxZoom: 14 });
                 

--- a/stickers/2333.html
+++ b/stickers/2333.html
@@ -8,7 +8,7 @@
 
     <!-- SEO Meta Tags - Pre-rendered for better indexing -->
     <meta name="description" content="Football sticker #2333 from Bodo glimt, Norway. Can you identify this Bodo glimt sticker? Browse our collection.">
-    <meta name="keywords" content="football stickers, 🇳🇴 Bodo glimt, Norway, panini, sticker collection, BodøGlimt Glimt HeiaGlimt Eliteserien GlimtFamily">
+    <meta name="keywords" content="Bodo glimt stickers, Bodo glimt football stickers, identify Bodo glimt sticker, Norway football stickers, football sticker database, Bod, Glimt, HeiaGlimt, Eliteserien, GlimtFamily">
     <link rel="canonical" href="https://stickerhunt.club/stickers/2333.html">
     
     <meta name="description" lang="de" content="Bodo glimt Fussball-Sticker #2333 -- kannst du ihn identifizieren? StickerHunt.">
@@ -146,10 +146,11 @@
                         <div class="sticker-detail-image-container" onclick="window.open('https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_617%2F1749912267389_IMG_5996.jpeg', '_blank')">
                             <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_617%2F1749912267389_IMG_5996_web.webp"
                                  alt="Bodo glimt football sticker -- from Prague, Norway -- Eliteserien club -- #2333"
+                                 data-sticker-id="2333"
                                  class="sticker-detail-image"
                                  decoding="async"
                                  loading="eager"
-                                 fetchpriority="high" data-sticker-id="2333">
+                                 fetchpriority="high">
                         </div>
                         <div class="sticker-nav-buttons"><a href="/stickers/2332.html" class="btn btn-nav sticker-nav-btn">← #2332</a><a href="/stickers/2334.html" class="btn btn-nav sticker-nav-btn">#2334 →</a></div>
                     </div>
@@ -201,7 +202,7 @@
                 <div class="more-from-club">
 <h3>More from Bodo glimt</h3>
 <div class="sticker-strip">
-<a href="/stickers/311.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Bodo_glimt/IMG_5675_thumb.webp?" alt="Sticker #311" loading="lazy" decoding="async" data-sticker-id="311"></a>
+<a href="/stickers/311.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Bodo_glimt/IMG_5675_thumb.webp?" alt="Sticker #311" data-sticker-id="311" loading="lazy" decoding="async"></a>
 </div>
 </div>
                 
@@ -211,12 +212,12 @@
                 <div class="nearby-stickers-section">
 <h3>Also found in Prague</h3>
 <div class="sticker-strip">
-<a href="/stickers/2332.html" class="sticker-strip-item" title="🇸🇪 Djurgardens IF"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_749%2F1749912243096_IMG_5997_thumb.webp" alt="🇸🇪 Djurgardens IF" loading="lazy" decoding="async" data-sticker-id="2332"></a>
-<a href="/stickers/2313.html" class="sticker-strip-item" title="🇩🇪 1 FC Union Berlin"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_945%2F1749910575342_IMG_5979_thumb.webp" alt="🇩🇪 1 FC Union Berlin" loading="lazy" decoding="async" data-sticker-id="2313"></a>
-<a href="/stickers/2312.html" class="sticker-strip-item" title="🇫🇷 Lille OSC"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_676%2F1749910551891_IMG_5980_thumb.webp" alt="🇫🇷 Lille OSC" loading="lazy" decoding="async" data-sticker-id="2312"></a>
-<a href="/stickers/2315.html" class="sticker-strip-item" title="🇩🇪 FC St Pauli"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_881%2F1749910838666_IMG_5955_thumb.webp" alt="🇩🇪 FC St Pauli" loading="lazy" decoding="async" data-sticker-id="2315"></a>
-<a href="/stickers/2311.html" class="sticker-strip-item" title="🇩🇪 Hannover 96"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_877%2F1749910520324_IMG_5978_thumb.webp" alt="🇩🇪 Hannover 96" loading="lazy" decoding="async" data-sticker-id="2311"></a>
-<a href="/stickers/2331.html" class="sticker-strip-item" title="🇩🇪 1 FC Köln"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_937%2F1749912217937_IMG_5999_thumb.webp" alt="🇩🇪 1 FC Köln" loading="lazy" decoding="async" data-sticker-id="2331"></a>
+<a href="/stickers/2332.html" class="sticker-strip-item" title="🇸🇪 Djurgardens IF"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_749%2F1749912243096_IMG_5997_thumb.webp" alt="🇸🇪 Djurgardens IF" data-sticker-id="2332" loading="lazy" decoding="async"></a>
+<a href="/stickers/2313.html" class="sticker-strip-item" title="🇩🇪 1 FC Union Berlin"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_945%2F1749910575342_IMG_5979_thumb.webp" alt="🇩🇪 1 FC Union Berlin" data-sticker-id="2313" loading="lazy" decoding="async"></a>
+<a href="/stickers/2312.html" class="sticker-strip-item" title="🇫🇷 Lille OSC"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_676%2F1749910551891_IMG_5980_thumb.webp" alt="🇫🇷 Lille OSC" data-sticker-id="2312" loading="lazy" decoding="async"></a>
+<a href="/stickers/2315.html" class="sticker-strip-item" title="🇩🇪 FC St Pauli"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_881%2F1749910838666_IMG_5955_thumb.webp" alt="🇩🇪 FC St Pauli" data-sticker-id="2315" loading="lazy" decoding="async"></a>
+<a href="/stickers/2311.html" class="sticker-strip-item" title="🇩🇪 Hannover 96"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_877%2F1749910520324_IMG_5978_thumb.webp" alt="🇩🇪 Hannover 96" data-sticker-id="2311" loading="lazy" decoding="async"></a>
+<a href="/stickers/2331.html" class="sticker-strip-item" title="🇩🇪 1 FC Köln"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_937%2F1749912217937_IMG_5999_thumb.webp" alt="🇩🇪 1 FC Köln" data-sticker-id="2331" loading="lazy" decoding="async"></a>
 </div>
 </div>
             </div>
@@ -344,19 +345,6 @@
                         opacity: 0.6
                     }).addTo(map)
                     .bindPopup('<div class="nearby-sticker-popup"><strong>FK Viktoria Žižkov</strong><a href="/stickers/2320.html" class="map-popup-link">View</a></div>');
-                })();
-
-                (function() {
-                    L.marker([50.0911638888889, 14.4272305555556], {
-                        icon: L.icon({
-                            iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
-                            iconSize: [18, 30],
-                            iconAnchor: [9, 30],
-                            popupAnchor: [1, -25]
-                        }),
-                        opacity: 0.6
-                    }).addTo(map)
-                    .bindPopup('<div class="nearby-sticker-popup"><strong>1 FC Magdeburg</strong><a href="/stickers/2328.html" class="map-popup-link">View</a></div>');
                 })();
 
                 (function() {
@@ -698,19 +686,6 @@
                 })();
 
                 (function() {
-                    L.marker([50.0774388888889, 14.4204083333333], {
-                        icon: L.icon({
-                            iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
-                            iconSize: [18, 30],
-                            iconAnchor: [9, 30],
-                            popupAnchor: [1, -25]
-                        }),
-                        opacity: 0.6
-                    }).addTo(map)
-                    .bindPopup('<div class="nearby-sticker-popup"><strong>Hansa Rostock</strong><a href="/stickers/2462.html" class="map-popup-link">View</a></div>');
-                })();
-
-                (function() {
                     L.marker([50.0774611111111, 14.4258916666667], {
                         icon: L.icon({
                             iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
@@ -945,19 +920,6 @@
                 })();
 
                 (function() {
-                    L.marker([50.0882027777778, 14.4477944444444], {
-                        icon: L.icon({
-                            iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
-                            iconSize: [18, 30],
-                            iconAnchor: [9, 30],
-                            popupAnchor: [1, -25]
-                        }),
-                        opacity: 0.6
-                    }).addTo(map)
-                    .bindPopup('<div class="nearby-sticker-popup"><strong>Nantes</strong><a href="/stickers/2318.html" class="map-popup-link">View</a></div>');
-                })();
-
-                (function() {
                     L.marker([50.0905333333333, 14.46045], {
                         icon: L.icon({
                             iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
@@ -1100,6 +1062,45 @@
                     .bindPopup('<div class="nearby-sticker-popup"><strong>Galatasaray</strong><a href="/stickers/2454.html" class="map-popup-link">View</a></div>');
                 })();
 
+                (function() {
+                    L.marker([50.0882027777778, 14.4477944444444], {
+                        icon: L.icon({
+                            iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+                            iconSize: [18, 30],
+                            iconAnchor: [9, 30],
+                            popupAnchor: [1, -25]
+                        }),
+                        opacity: 0.6
+                    }).addTo(map)
+                    .bindPopup('<div class="nearby-sticker-popup"><strong>Nantes</strong><a href="/stickers/2318.html" class="map-popup-link">View</a></div>');
+                })();
+
+                (function() {
+                    L.marker([50.0911638888889, 14.4272305555556], {
+                        icon: L.icon({
+                            iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+                            iconSize: [18, 30],
+                            iconAnchor: [9, 30],
+                            popupAnchor: [1, -25]
+                        }),
+                        opacity: 0.6
+                    }).addTo(map)
+                    .bindPopup('<div class="nearby-sticker-popup"><strong>1 FC Magdeburg</strong><a href="/stickers/2328.html" class="map-popup-link">View</a></div>');
+                })();
+
+                (function() {
+                    L.marker([50.0774388888889, 14.4204083333333], {
+                        icon: L.icon({
+                            iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+                            iconSize: [18, 30],
+                            iconAnchor: [9, 30],
+                            popupAnchor: [1, -25]
+                        }),
+                        opacity: 0.6
+                    }).addTo(map)
+                    .bindPopup('<div class="nearby-sticker-popup"><strong>Hansa Rostock</strong><a href="/stickers/2462.html" class="map-popup-link">View</a></div>');
+                })();
+
                 // Current sticker — larger marker, opened popup
                 L.marker([50.0877, 14.3901138888889], {
                     icon: L.icon({
@@ -1125,7 +1126,6 @@
                     [50.0709222222222, 14.4151722222222],
                     [50.0972583333333, 14.4636611111111],
                     [50.0887638888889, 14.4612861111111],
-                    [50.0911638888889, 14.4272305555556],
                     [50.0876777777778, 14.390175],
                     [50.0876805555556, 14.3912305555556],
                     [50.0916111111111, 14.4489305555556],
@@ -1152,7 +1152,6 @@
                     [50.0773805555556, 14.423675],
                     [50.0775027777778, 14.4204694444444],
                     [50.0779305555556, 14.4195166666667],
-                    [50.0774388888889, 14.4204083333333],
                     [50.0774611111111, 14.4258916666667],
                     [50.0845555555556, 14.4135694444444],
                     [50.0782361111111, 14.4191444444444],
@@ -1167,7 +1166,9 @@
                     [50.0845527777778, 14.4135583333333],
                     [50.0881888888889, 14.4477583333333],
                     [50.0911972222222, 14.4271972222222],
-                    [50.0903166666667, 14.45905]
+                    [50.0903166666667, 14.45905],
+                    [50.0918833333333, 14.4263916666667],
+                    [50.078025, 14.4178972222222]
                 ]);
                 map.fitBounds(bounds, { padding: [30, 30], maxZoom: 14 });
                 

--- a/stickers/310.html
+++ b/stickers/310.html
@@ -8,7 +8,7 @@
 
     <!-- SEO Meta Tags - Pre-rendered for better indexing -->
     <meta name="description" content="Football sticker #310 from UD Leiria, Portugal. Can you identify this UD Leiria sticker? Browse our collection.">
-    <meta name="keywords" content="football stickers, 🇵🇹 UD Leiria, Portugal, panini, sticker collection, UDLeiria Leiria LigaPortugal Futebol UDL">
+    <meta name="keywords" content="UD Leiria stickers, UD Leiria football stickers, identify UD Leiria sticker, Portugal football stickers, football sticker database, UDLeiria, Leiria, LigaPortugal, Futebol, UDL">
     <link rel="canonical" href="https://stickerhunt.club/stickers/310.html">
     
     <meta name="description" lang="de" content="UD Leiria Fussball-Sticker #310 -- kannst du ihn identifizieren? StickerHunt.">
@@ -146,10 +146,11 @@
                         <div class="sticker-detail-image-container" onclick="window.open('https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/UD_Leiria/IMG_8173.jpeg?', '_blank')">
                             <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/UD_Leiria/IMG_8173_web.webp?"
                                  alt="UD Leiria football sticker -- from Portugal -- Terceira Divisão club -- #310"
+                                 data-sticker-id="310"
                                  class="sticker-detail-image"
                                  decoding="async"
                                  loading="eager"
-                                 fetchpriority="high" data-sticker-id="310">
+                                 fetchpriority="high">
                         </div>
                         <div class="sticker-nav-buttons"><a href="/stickers/309.html" class="btn btn-nav sticker-nav-btn">← #309</a><a href="/stickers/311.html" class="btn btn-nav sticker-nav-btn">#311 →</a></div>
                     </div>
@@ -201,9 +202,9 @@
                 <div class="more-from-club">
 <h3>More from UD Leiria</h3>
 <div class="sticker-strip">
-<a href="/stickers/307.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/UD_Leiria/IMG_4646_thumb.webp?" alt="Sticker #307" loading="lazy" decoding="async" data-sticker-id="307"></a>
-<a href="/stickers/308.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/UD_Leiria/IMG_4135_thumb.webp?" alt="Sticker #308" loading="lazy" decoding="async" data-sticker-id="308"></a>
-<a href="/stickers/309.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/UD_Leiria/IMG_8223_(1)_thumb.webp?" alt="Sticker #309" loading="lazy" decoding="async" data-sticker-id="309"></a>
+<a href="/stickers/307.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/UD_Leiria/IMG_4646_thumb.webp?" alt="Sticker #307" data-sticker-id="307" loading="lazy" decoding="async"></a>
+<a href="/stickers/308.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/UD_Leiria/IMG_4135_thumb.webp?" alt="Sticker #308" data-sticker-id="308" loading="lazy" decoding="async"></a>
+<a href="/stickers/309.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/UD_Leiria/IMG_8223_(1)_thumb.webp?" alt="Sticker #309" data-sticker-id="309" loading="lazy" decoding="async"></a>
 </div>
 </div>
                 

--- a/stickers/311.html
+++ b/stickers/311.html
@@ -8,7 +8,7 @@
 
     <!-- SEO Meta Tags - Pre-rendered for better indexing -->
     <meta name="description" content="Football sticker #311 from Bodo glimt, Norway. Can you identify this Bodo glimt sticker? Browse our collection.">
-    <meta name="keywords" content="football stickers, 🇳🇴 Bodo glimt, Norway, panini, sticker collection, BodøGlimt Glimt HeiaGlimt Eliteserien GlimtFamily">
+    <meta name="keywords" content="Bodo glimt stickers, Bodo glimt football stickers, identify Bodo glimt sticker, Norway football stickers, football sticker database, Bod, Glimt, HeiaGlimt, Eliteserien, GlimtFamily">
     <link rel="canonical" href="https://stickerhunt.club/stickers/311.html">
     
     <meta name="description" lang="de" content="Bodo glimt Fussball-Sticker #311 -- kannst du ihn identifizieren? StickerHunt.">
@@ -146,10 +146,11 @@
                         <div class="sticker-detail-image-container" onclick="window.open('https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Bodo_glimt/IMG_5675.jpeg?', '_blank')">
                             <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/Bodo_glimt/IMG_5675_web.webp?"
                                  alt="Bodo glimt football sticker -- from Norway -- Eliteserien club -- #311"
+                                 data-sticker-id="311"
                                  class="sticker-detail-image"
                                  decoding="async"
                                  loading="eager"
-                                 fetchpriority="high" data-sticker-id="311">
+                                 fetchpriority="high">
                         </div>
                         <div class="sticker-nav-buttons"><a href="/stickers/310.html" class="btn btn-nav sticker-nav-btn">← #310</a><a href="/stickers/312.html" class="btn btn-nav sticker-nav-btn">#312 →</a></div>
                     </div>
@@ -201,7 +202,7 @@
                 <div class="more-from-club">
 <h3>More from Bodo glimt</h3>
 <div class="sticker-strip">
-<a href="/stickers/2333.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_617%2F1749912267389_IMG_5996_thumb.webp" alt="Sticker #2333" loading="lazy" decoding="async" data-sticker-id="2333"></a>
+<a href="/stickers/2333.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/club_617%2F1749912267389_IMG_5996_thumb.webp" alt="Sticker #2333" data-sticker-id="2333" loading="lazy" decoding="async"></a>
 </div>
 </div>
                 

--- a/stickers/312.html
+++ b/stickers/312.html
@@ -8,7 +8,7 @@
 
     <!-- SEO Meta Tags - Pre-rendered for better indexing -->
     <meta name="description" content="Football sticker #312 from FC Dinamo București, Romania. Can you identify this FC Dinamo București sticker? Browse our collection.">
-    <meta name="keywords" content="football stickers, 🇷🇴 FC Dinamo București, Romania, panini, sticker collection, FCSDinamoBucuresti DinamoBucuresti Dinamo1948 ForzaDinamo Liga1">
+    <meta name="keywords" content="FC Dinamo București stickers, FC Dinamo București football stickers, identify FC Dinamo București sticker, Romania football stickers, football sticker database, FCSDinamoBucuresti, DinamoBucuresti, Dinamo1948, ForzaDinamo, Liga1">
     <link rel="canonical" href="https://stickerhunt.club/stickers/312.html">
     
     <meta name="description" lang="de" content="FC Dinamo București Fussball-Sticker #312 -- kannst du ihn identifizieren? StickerHunt.">
@@ -146,10 +146,11 @@
                         <div class="sticker-detail-image-container" onclick="window.open('https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Dinamo_Bucuresti/IMG_4155_(2).jpeg?', '_blank')">
                             <img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Dinamo_Bucuresti/IMG_4155_(2)_web.webp?"
                                  alt="FC Dinamo București football sticker -- from Romania -- Liga I club -- #312"
+                                 data-sticker-id="312"
                                  class="sticker-detail-image"
                                  decoding="async"
                                  loading="eager"
-                                 fetchpriority="high" data-sticker-id="312">
+                                 fetchpriority="high">
                         </div>
                         <div class="sticker-nav-buttons"><a href="/stickers/311.html" class="btn btn-nav sticker-nav-btn">← #311</a><a href="/stickers/313.html" class="btn btn-nav sticker-nav-btn">#313 →</a></div>
                     </div>
@@ -201,7 +202,7 @@
                 <div class="more-from-club">
 <h3>More from FC Dinamo București</h3>
 <div class="sticker-strip">
-<a href="/stickers/313.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Dinamo_Bucuresti/IMG_8397_(1)_thumb.webp?" alt="Sticker #313" loading="lazy" decoding="async" data-sticker-id="313"></a>
+<a href="/stickers/313.html" class="sticker-strip-item"><img src="https://rbmeslzlbsolkxnvesqb.supabase.co/storage/v1/object/public/stickers/stickers/FC_Dinamo_Bucuresti/IMG_8397_(1)_thumb.webp?" alt="Sticker #313" data-sticker-id="313" loading="lazy" decoding="async"></a>
 </div>
 </div>
                 

--- a/tests/e2e/view-count.spec.js
+++ b/tests/e2e/view-count.spec.js
@@ -131,9 +131,10 @@ test('tracks views, renders badges, and excludes quiz and battle badges', async 
 
     const beforeCount = await getViewCount(page, CLUB_STICKER_ID);
 
+    // Club, country, city: tracking fires but badge must NOT render.
     await page.goto(CLUB_PAGE_URL);
     await page.waitForLoadState('domcontentloaded');
-    await expect(page.locator('.sticker-view-badge').first()).toBeVisible();
+    await expect(page.locator('.sticker-view-badge')).toHaveCount(0);
     await waitForTrackedImage(page, '.sticker-gallery img[data-sticker-id="20"]');
     await page.screenshot({ path: testInfo.outputPath('club-page.png'), fullPage: true });
 
@@ -144,14 +145,15 @@ test('tracks views, renders badges, and excludes quiz and battle badges', async 
 
     await page.goto(COUNTRY_PAGE_URL);
     await page.waitForLoadState('domcontentloaded');
-    await expect(page.locator('.cat-country-card .sticker-view-badge').first()).toBeVisible();
+    await expect(page.locator('.sticker-view-badge')).toHaveCount(0);
     await page.screenshot({ path: testInfo.outputPath('country-page.png'), fullPage: true });
 
     await page.goto(CITY_PAGE_URL);
     await page.waitForLoadState('domcontentloaded');
-    await expect(page.locator('.sticker-gallery .sticker-view-badge').first()).toBeVisible();
+    await expect(page.locator('.sticker-view-badge')).toHaveCount(0);
     await page.screenshot({ path: testInfo.outputPath('city-page.png'), fullPage: true });
 
+    // Sticker page: badge IS rendered.
     await page.goto(STICKER_PAGE_URL);
     await page.waitForLoadState('domcontentloaded');
     await expect(page.locator('.sticker-detail-image-container .sticker-view-badge')).toBeVisible();


### PR DESCRIPTION
## Summary
Narrow `isBadgePage()` in `js/view-tracker.js` to match only `/stickers/{id}.html`. Everywhere else the tracker still observes impressions and increments `view_count`, but the visual eye-icon badge is no longer rendered on club / country / city / catalogue / homepage.

## Why
Counts visible during browsing leak popularity hints. Surfacing them only on the sticker detail page keeps the rest of the UI clean.

## Test plan
- [x] Updated `tests/e2e/view-count.spec.js`: club/country/city assert `.sticker-view-badge` count is 0; sticker page still asserts visible badge; tracking RPC still fires from club page.
- [x] `npx playwright test tests/e2e/view-count.spec.js` passes locally (15s).
