### PR TITLE
fix: badge only on hero sticker, not related thumbnails

### DIFF
--- a/js/view-tracker.js
+++ b/js/view-tracker.js
@@ -119,8 +119,10 @@
     }
 
     function getBadgeHost(img) {
-        return img.closest('.sticker-detail-image-container, .sticker-preview-link, .hp-sticker-card, .cat-club-card, .cat-country-card')
-            || img.parentElement;
+        // Badge only on the hero sticker on /stickers/{id}.html — never on
+        // "More stickers" / related thumbnails. Returning null makes
+        // ensureBadge() bail without painting anything.
+        return img.closest('.sticker-detail-image-container');
     }
 
     function formatViewCount(value) {

--- a/tests/e2e/view-count.spec.js
+++ b/tests/e2e/view-count.spec.js
@@ -153,10 +153,12 @@ test('tracks views, renders badges, and excludes quiz and battle badges', async 
     await expect(page.locator('.sticker-view-badge')).toHaveCount(0);
     await page.screenshot({ path: testInfo.outputPath('city-page.png'), fullPage: true });
 
-    // Sticker page: badge IS rendered.
+    // Sticker page: badge IS rendered, but ONLY on the hero image.
+    // "More stickers" / related thumbnails must stay clean.
     await page.goto(STICKER_PAGE_URL);
     await page.waitForLoadState('domcontentloaded');
     await expect(page.locator('.sticker-detail-image-container .sticker-view-badge')).toBeVisible();
+    await expect(page.locator('.sticker-view-badge')).toHaveCount(1);
     await page.screenshot({ path: testInfo.outputPath('sticker-page.png'), fullPage: true });
 
     const rpcCountBeforeQuiz = rpcPayloads.length;


### PR DESCRIPTION
## Summary
On `/stickers/{id}.html`, render the view-count badge **only on the hero image** (`.sticker-detail-image-container`). The "More stickers" / related thumbnails further down the page no longer get the badge.

Tracking remains unchanged — every visible sticker still increments `view_count` in the DB.

## Test plan
- [x] `tests/e2e/view-count.spec.js` now asserts exactly 1 `.sticker-view-badge` on the sticker detail page.
- [x] `npx playwright test` passes locally.
